### PR TITLE
Merged omega and nth-omega

### DIFF
--- a/app/assets/stylesheets/grid/_grid.scss
+++ b/app/assets/stylesheets/grid/_grid.scss
@@ -106,7 +106,7 @@ $fg-max-width: $max-width;
 }
 
 @mixin nth-omega($nth, $display: block, $direction: right) {
-  @warn "The nth-omega() mixin was deplecated. Please use omega()";
+  @warn "The nth-omega() mixin was deprecated. Please use omega()";
   @include omega($nth, $display, $direction);
 }
 


### PR DESCRIPTION
This pull request is about #32 conversation,

I think a lot about backward compatibility, I created a small project to test the css property of element,  can see here(https://github.com/dukex/neat_test_example) 

Now, it:

``` scss
// old omega
.omega-default{  @include omega; }
.omega-table{  @include omega(table); }
.omega-default-left{  @include omega(block, left); }
.omega-table-left{  @include omega(table, left); }

// old nth-omega merged
.omega-nth-default{ @include omega(4n) }
.omega-nth-table{  @include omega(4n, table); }
.omega-nth-default-left{  @include omega(4n, block, left); }
.omega-nth-table-left{  @include omega(4n, table, left); }
```

Will be compiled to it:

``` css
.omega-default { margin-right: 0; }
.omega-table { padding-right: 0; }
.omega-default-left { margin-left: 0; }
.omega-table-left { padding-left: 0; }

.omega-nth-default:nth-child(4n) { margin-right: 0; }
.omega-nth-table:nth-child(4n) { padding-right: 0; }
.omega-nth-default-left:nth-child(4n) {  margin-left: 0; }
.omega-nth-table-left:nth-child(4n) { padding-left: 0; }
```
