### PR TITLE
Add explicit require to bourbon when loading

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -1,3 +1,4 @@
+require "bourbon"
 require "neat/generator"
 
 module Neat


### PR DESCRIPTION
If only `gem 'neat'` is specified in Gemfile for Rails 3.2.9 app (as per readme), bourbon gem is never loaded and subsequently its assets are not made available to asset pipeline, leading to exception on `@import "bourbon"` statement.
