### PR TITLE
Add stylesheets path to Sass.load_paths

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -14,5 +14,7 @@ module Neat
         end
       end
     end
+  else
+    Sass.load_paths << File.expand_path("../../app/assets/stylesheets", __FILE__)
   end
 end


### PR DESCRIPTION
I'm just mirroring [this commit](https://github.com/thoughtbot/bourbon/commit/b7abce3b105aaae36fd6c3453f54e3308ecb7c90) in Bourbon.
