### PR TITLE
Support frameworks that add extra elements to your markup

### DIFF
--- a/app/assets/stylesheets/grid/_omega.scss
+++ b/app/assets/stylesheets/grid/_omega.scss
@@ -11,7 +11,7 @@
 
   @if length($query) == 1 {
     @if $auto {
-      &:last-child {
+      &:last-child, &:last-of-type {
         margin-#{$direction}: 0;
       }
     }
@@ -34,7 +34,7 @@
   @else if length($query) == 2 {
     @if $table {
       @if $auto {
-        &:last-child {
+        &:last-child, &:last-of-type {
           padding-#{$direction}: 0;
         }
       }
@@ -48,7 +48,7 @@
 
     @else {
       @if $auto {
-        &:last-child {
+        &:last-child, &:last-of-type {
           margin-#{$direction}: 0;
         }
       }

--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -26,7 +26,7 @@
     padding-#{$direction}: flex-gutter($container-columns);
     width: flex-grid($columns, $container-columns) + flex-gutter($container-columns);
 
-    &:last-child {
+    &:last-child, &:last-of-type {
       width: flex-grid($columns, $container-columns);
       padding-#{$direction}: 0;
     }
@@ -38,7 +38,7 @@
     margin-#{$direction}: flex-gutter($container-columns);
     width: flex-grid($columns, $container-columns);
 
-    &:last-child {
+    &:last-child, &:last-of-type {
       margin-#{$direction}: 0;
     }
   }

--- a/spec/neat/columns_spec.rb
+++ b/spec/neat/columns_spec.rb
@@ -25,6 +25,10 @@ describe "@include span-columns()" do
     it "removes gutter from last element" do
       expect('.span-columns-default:last-child').to have_rule('margin-right: 0')
     end
+
+    it "removes the gutter from the last element of a type" do
+      expect('.span-columns-default:last-of-type').to have_rule('margin-right: 0')
+    end
   end
 
   context "when nested" do
@@ -48,6 +52,10 @@ describe "@include span-columns()" do
 
     it "substracts gutter from width of last element" do
       expect('.span-columns-table:last-child').to have_rule('width: 48.82117%')
+    end
+
+    it "subtracts gutter from the last element of a type" do
+      expect('.span-columns-table:last-of-type').to have_rule('width: 48.82117%')
     end
   end
 end


### PR DESCRIPTION
I really like Neat but right now it's not a good fit for an Ember application.  Ember adds extra "metamorph" script tags to the markup which means that trying to strip the margin on the last-child won't work for `span-columns()`.

This pull request uses the last-of-type selector to target the last element that you would actually want to remove margin from.  Unfortunately this selector doesn't work on IE8 and earlier.  Still, I think this is a useful feature.
