### PR TITLE
Add `$display: collapse` argument to `span-columns`

### DIFF
--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -35,8 +35,15 @@
   @else {
     display: block;
     float: #{$opposite-direction};
-    margin-#{$direction}: flex-gutter($container-columns);
-    width: flex-grid($columns, $container-columns);
+
+		@if $display == collapse {
+			width: flex-grid($columns, $container-columns) + flex-gutter($container-columns);
+		}
+
+		@else {
+			margin-#{$direction}: flex-gutter($container-columns);
+			width: flex-grid($columns, $container-columns);
+		}
 
     &:last-child {
       margin-#{$direction}: 0;

--- a/spec/neat/columns_spec.rb
+++ b/spec/neat/columns_spec.rb
@@ -50,4 +50,14 @@ describe "@include span-columns()" do
       expect('.span-columns-table:last-child').to have_rule('width: 48.82117%')
     end
   end
+
+	context "with argument (collapse)" do
+		it "appends gutter width to column width" do
+			expect('.span-columns-collapse').to have_rule('width: 51.17883%')
+		end
+
+		it "removes the next gutter" do
+			expect('.span-columns-collapse').to_not have_rule('margin-right')
+		end
+	end
 end

--- a/test/span-columns.scss
+++ b/test/span-columns.scss
@@ -15,3 +15,7 @@
 .span-columns-inline-block {
   @include span-columns(6, inline-block);
 }
+
+.span-columns-collapse {
+	@include span-columns(6, collapse);
+}


### PR DESCRIPTION
`@include span-columns(6, collapse);` removes the next gutter and
extends the element's width to cover it.
