### PR TITLE
Re-order breakpoints due to cascading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ $grid-columns: 10;
 $max-width: em(1088);
 
 // Define your breakpoints
-$mobile: new-breakpoint(max-width 480px 4);
 $tablet: new-breakpoint(max-width 768px 8);
+$mobile: new-breakpoint(max-width 480px 4);
 ```
 
 See the [docs](http://neat.bourbon.io/docs/#variables) for a full list of settings.


### PR DESCRIPTION
Because these generate rules for the visual grid, they need to be defined in this order so they cascade correctly. Without this, when on a mobile-sized screen, you'd see 8 visual columns, even though there were only 4 being used.
