### PR TITLE
Remove px-to-em as it is in Bourbon

### DIFF
--- a/app/assets/stylesheets/_neat-helpers.scss
+++ b/app/assets/stylesheets/_neat-helpers.scss
@@ -1,7 +1,6 @@
 // Functions
 @import "functions/private";
 @import "functions/new-breakpoint";
-@import "functions/px-to-em";
 
 // Settings
 @import "settings/grid";

--- a/app/assets/stylesheets/functions/_px-to-em.scss
+++ b/app/assets/stylesheets/functions/_px-to-em.scss
@@ -1,3 +1,0 @@
-@function em($pxval, $base: 16) {
-  @return ($pxval / $base) * 1em;
-}


### PR DESCRIPTION
This function is in Bourbon https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/functions/_px-to-em.scss and is out of date. It is no longer needed in Neat.
