### PR TITLE
Add gutterless display option to span-columns

### DIFF
--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -26,6 +26,13 @@
         width: flex-grid($columns, $container-columns);
       }
 
+    } @else if $display == gutterless {
+      width: percentage($columns / $container-columns);
+
+      &:last-child {
+        width: percentage($columns / $container-columns);
+      }
+
     } @else {
       margin-#{$direction}: flex-gutter($container-columns);
       width: flex-grid($columns, $container-columns);

--- a/spec/neat/columns_spec.rb
+++ b/spec/neat/columns_spec.rb
@@ -60,4 +60,18 @@ describe "@include span-columns()" do
       expect('.span-columns-collapse:last-child').to have_rule('width: 48.82117%')
     end
   end
+
+  context "with argument (gutterless)" do
+    it "removes gutter width from column width calculation" do
+      expect('.span-columns-gutterless').to have_rule('width: 50%')
+    end
+
+    it "removes the next gutter" do
+      expect('.span-columns-gutterless').to_not have_rule('margin-right')
+    end
+
+    it "ensures the width of the last child is not affected by the gutter width" do
+      expect('.span-columns-gutterless:last-child').to have_rule('width: 50%')
+    end
+  end
 end

--- a/test/span-columns.scss
+++ b/test/span-columns.scss
@@ -19,3 +19,7 @@
 .span-columns-collapse {
   @include span-columns(6, collapse);
 }
+
+.span-columns-gutterless {
+  @include span-columns(6, gutterless);
+}


### PR DESCRIPTION
This adds a new display option `gutterless` to span-columns that uses a simple percentage calculation so that developers/designers have options on how they want to collapse gutters.

I added the `gutterless` option rather than changing `collapse` because a percentage calculation on `collapse` could have ill effects when someone attempts to mix collapse with the default display mode.

I assume that this will bring up discussion rather than be merged immediately since it is a new feature with added complexity.

Fixes #104
