### PR TITLE
Clarify when to use shift()

### DIFF
--- a/_posts/docs/mixins/00-01-10-shift.markdown
+++ b/_posts/docs/mixins/00-01-10-shift.markdown
@@ -12,7 +12,7 @@ permalink: /redirect
 shift($columns)
 {% endhighlight %}
 
-The `shift()` mixin translates an element horizontally by a number of columns. Positive arguments shift the element to the active layout direction, while negative ones shift it to the opposite direction.
+The `shift()` mixin translates an element horizontally by a number of columns. Positive arguments shift the element to the active layout direction, while negative ones shift it to the opposite direction. As this affects `margin-left`, be sure to include it after other mixins such as `span-columns()`.
 
 {% highlight sass %}
 @param $columns (required)


### PR DESCRIPTION
I spent a good chunk of time trying to work out why an element was off grid. After much head scratching I wondered if the order in which the mixins were being included had an effect. I hope this clarification in the documentation will give someone that ah-ha moment sooner.
