### PR TITLE
Replace *-child, with *-of-type

### DIFF
--- a/app/assets/stylesheets/grid/_omega.scss
+++ b/app/assets/stylesheets/grid/_omega.scss
@@ -15,7 +15,7 @@
 
   @if length($query) == 1 {
     @if $auto {
-      &:last-child {
+      &:last-of-type {
         margin-#{$direction}: 0;
       }
     }
@@ -31,7 +31,7 @@
 
   @else if length($query) == 2 {
     @if $auto {
-      &:last-child {
+      &:last-of-type {
         margin-#{$direction}: 0;
       }
     }
@@ -49,12 +49,12 @@
 @mixin nth-child($query, $direction) {
   $opposite-direction: get-opposite-direction($direction);
 
-  &:nth-child(#{$query}) {
+  &:nth-of-type(#{$query}) {
     margin-#{$direction}: 0;
   }
 
   @if type-of($query) == number {
-    &:nth-child(#{$query}+1) {
+    &:nth-of-type(#{$query}+1) {
       clear: $opposite-direction;
     }
   }

--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -27,7 +27,7 @@
     @if $display == collapse or $display == block-collapse {
       width: flex-grid($columns, $container-columns) + flex-gutter($container-columns);
 
-      &:last-child {
+      &:last-of-type {
         width: flex-grid($columns, $container-columns);
       }
 
@@ -35,7 +35,7 @@
       margin-#{$direction}: flex-gutter($container-columns);
       width: flex-grid($columns, $container-columns);
 
-      &:last-child {
+      &:last-of-type {
         margin-#{$direction}: 0;
       }
     }

--- a/spec/neat/columns_spec.rb
+++ b/spec/neat/columns_spec.rb
@@ -23,7 +23,7 @@ describe "@include span-columns()" do
     end
 
     it "removes gutter from last element" do
-      expect('.span-columns-default:last-child').to have_rule('margin-right: 0')
+      expect('.span-columns-default:last-of-type').to have_rule('margin-right: 0')
     end
   end
 
@@ -56,8 +56,8 @@ describe "@include span-columns()" do
       expect('.span-columns-collapse').to_not have_rule('margin-right: 2.35765%')
     end
 
-    it "removes gutter percentage from the width of the last child" do
-      expect('.span-columns-collapse:last-child').to have_rule('width: 48.82117%')
+    it "removes gutter percentage from the width of the last of type" do
+      expect('.span-columns-collapse:last-of-type').to have_rule('width: 48.82117%')
     end
   end
 

--- a/spec/neat/omega_spec.rb
+++ b/spec/neat/omega_spec.rb
@@ -12,18 +12,18 @@ describe "@include omega()" do
   end
 
   context "with argument (4n)" do
-    it "removes right margin of nth-child(4n)" do
-      expect('.omega-nth-default:nth-child(4n)').to have_rule('margin-right: 0')
+    it "removes right margin of nth-of-type(4n)" do
+      expect('.omega-nth-default:nth-of-type(4n)').to have_rule('margin-right: 0')
     end
 
-    it "adds clear to nth-child(4n+1)" do
-      expect('.omega-nth-default:nth-child(4n+1)').to have_rule('clear: left')
+    it "adds clear to nth-of-type(4n+1)" do
+      expect('.omega-nth-default:nth-of-type(4n+1)').to have_rule('clear: left')
     end
   end
 
   context "with argument ('4n+1')" do
-    it "removes right margin of nth-child(4n+1)" do
-      expect('.omega-complex-nth:nth-child(4n+1)').to have_rule('margin-right: 0')
+    it "removes right margin of nth-of-type(4n+1)" do
+      expect('.omega-complex-nth:nth-of-type(4n+1)').to have_rule('margin-right: 0')
     end
   end
 
@@ -35,8 +35,8 @@ describe "@include omega()" do
     end
 
     context "with argument (4n block)" do
-      it "removes left margin of nth-child(4n)" do
-        expect('section .omega-nth-default-left:nth-child(4n)').to have_rule('margin-left: 0')
+      it "removes left margin of nth-of-type(4n)" do
+        expect('section .omega-nth-default-left:nth-of-type(4n)').to have_rule('margin-left: 0')
       end
     end
   end


### PR DESCRIPTION
Frameworks like Ember.js use a technique called metamorph ( http://emberjs.com/guides/understanding-ember/keeping-templates-up-to-date/ )
Basically script tags are added on places between items that need to be observed so the engine can find a reference later.

*-child properties include these tags and result in non-desired behavior (mostly omega not working properly, ..)
The *-of-type property behaves most like the -child property but takes the actual element into account hence ignoring the script tags in the case described above.
