### PR TITLE
Simpler `is-even` and `belongs-to` functions

### DIFF
--- a/app/assets/stylesheets/functions/_private.scss
+++ b/app/assets/stylesheets/functions/_private.scss
@@ -10,11 +10,10 @@
 
 // Contains display value
 @function contains-display-value($query) {
-  @if belongs-to(table, $query) or belongs-to(block, $query) or belongs-to(inline-block, $query) or belongs-to(inline, $query) {
-    @return true;
-  }
-
-  @return false;
+  @return belongs-to(table, $query) 
+       or belongs-to(block, $query) 
+       or belongs-to(inline-block, $query) 
+       or belongs-to(inline, $query);
 }
 
 // Parses the first argument of span-columns()


### PR DESCRIPTION
From a strictly syntactic standpoint, the `is-even` function could be written like this:

``` scss
@function is-even($int) {
  @return $int % 2 == 0
}
```

Same goes for `belongs-to`:

``` scss
@function belongs-to($tested-item, $list) {
  @return index($list, $tested-item) != false;
}
```

... and this makes `contains-display-value` easier as well.

Any reason not to do so?
