### PR TITLE
Move clearfix to only apply to display:block rows

### DIFF
--- a/app/assets/stylesheets/grid/_row.scss
+++ b/app/assets/stylesheets/grid/_row.scss
@@ -1,5 +1,4 @@
 @mixin row($display: block, $direction: $default-layout-direction) {
-  @include clearfix;
   $layout-direction: $direction !global;
 
   @if $display == table {
@@ -10,6 +9,7 @@
   }
 
   @else {
+    @include clearfix;
     display: block;
     $container-display-table: false !global;
   }


### PR DESCRIPTION
Applying the `@include clearfix;` to table-based rows will result in a 1px spacing on the right of the table in some browsers (Chrome 35 on Mac as an example). Clearfix is not needed for elements when using display:table; so it should be safe to apply clearfix to block-based rows only.
