### PR TITLE
Change to standard CSS comment for manifest version

### DIFF
--- a/app/assets/stylesheets/_neat.scss
+++ b/app/assets/stylesheets/_neat.scss
@@ -1,6 +1,7 @@
-// Bourbon Neat 1.6.0
-// MIT Licensed
-// Copyright (c) 2012-2013 thoughtbot, inc.
+/* Neat 1.6.0
+ * http://neat.bourbon.io
+ * Copyright 2012–2014 thoughtbot, inc.
+ * MIT License */
 
 // Helpers
 @import "neat-helpers";


### PR DESCRIPTION
Per [this PR](https://github.com/thoughtbot/bourbon/pull/476) for Bourbon, this is a slight modification to how we handle version info in the main manifest file.
