### PR TITLE
README restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,130 @@
-[![Bourbon Neat](http://neat.bourbon.io/images/logotype.svg)](http://thoughtbot.com/neat)
-
--
+[![Neat](http://neat.bourbon.io/images/logotype.svg)](http://neat.bourbon.io)
 
 [![Gem Version](http://img.shields.io/gem/v/neat.svg?style=flat)](https://rubygems.org/gems/neat) [![Travis](http://img.shields.io/travis/thoughtbot/neat.svg?style=flat)](https://travis-ci.org/thoughtbot/neat)
 [![Code Climate](http://img.shields.io/codeclimate/github/thoughtbot/neat.svg?style=flat)](https://codeclimate.com/github/thoughtbot/neat)
 [![IRC](http://img.shields.io/badge/freenode-%23bourbon--neat-ae3dd2.svg?style=flat)](#)
 [![Stack Overflow](http://img.shields.io/badge/stack%20overflow-neat-ae3dd2.svg?style=flat)](http://stackoverflow.com/questions/tagged/neat)
 
-Neat is an open source fluid grid framework built on top of [Bourbon](http://bourbon.io) with the aim of being easy enough to use out of the box and flexible enough to customize down the road.
+***
 
-:warning: Neat **1.6.0** requires Sass **3.3.x**. If you are using **libsass** or **sass-rails** use **1.5.1**.
+## A lightweight, semantic grid framework built on top of Bourbon
 
-Requirements
-===
-- Sass 3.3+
-- Bourbon 3.1+
+Neat is a fluid grid framework built on [Bourbon](http://bourbon.io) with the aim of being easy enough to use out of the box and flexible enough to customize down the road.
 
-Install Instructions
-===
-Install/update the dependencies first:
+#### [Documentation & Demo](http://neat.bourbon.io)
+
+#### [Changelog](https://github.com/thoughtbot/neat/releases)
+
+## Requirements
+
+- [Sass](https://github.com/sass/sass) 3.3+
+- [Bourbon](https://github.com/thoughtbot/bourbon) 3.1+
+- :warning: If you are using Neat with **LibSass**, **sass-rails**, **Compass**, **Foundation** or need **Sass 3.2 support**, you should [use Neat 1.5.1](#installing-older-versions-of-neat).
+
+## Installation
+
+Neat uses the [RubyGems](https://rubygems.org) package manager to easily generate a `neat` directory with all of the necessary files.
+
+1. Install the Neat gem:
+
+  ```bash
+  gem install neat
+  ```
+
+2. Install or update Neat’s dependencies:
+
+  ```bash
+  gem install sass # or gem update sass
+  ```
+  ```bash
+  gem install bourbon # or gem update bourbon
+  ```
+
+3. Install the Neat library into the current directory:
+
+  ```bash
+  bourbon install # if not already installed
+  ```
+  ```bash
+  neat install
+  ```
+
+4. Import Neat in your stylesheet, after Bourbon:
+
+  ```scss
+  @import "bourbon/bourbon";
+  @import "neat/neat";
+  ```
+
+  It’s not recommended to add or modify the Neat files so that you can update them easily.
+
+## Installation for Ruby on Rails
+
+1. Add Neat to your Gemfile:
+
+  ```ruby
+  gem 'neat'
+  ```
+
+2. Then run:
+
+  ```bash
+  bundle install
+  ```
+
+  If you see the error `Bundler could not find compatible versions for gem "sass"`, run:
+
+  ```bash
+  bundle update sass
+  ```
+
+3. Import Neat in your `application.css.scss`, after Bourbon:
+
+  ```scss
+  @import "bourbon";
+  @import "neat";
+  ```
+
+## Installing older versions of Neat
+
+1. Uninstall any Neat gem versions you already have:
+
+  ```bash
+  gem uninstall neat
+  ```
+
+2. Reinstall the Neat gem, using the `-v` flag to specify the version you need:
+
+  ```bash
+  gem install neat -v 1.5.1
+  ```
+
+3. Follow the [instructions above](#installation) to install Neat into your project.
+
+## Command line interface
 
 ```bash
-gem install sass #or gem update sass
-gem install bourbon #or gem update bourbon
-```
-Install Neat:
-
-```bash
-gem install neat
-```
-Then `cd` to your Sass directory and run:
-
-```bash
-bourbon install #If not installed
 neat install
-```
-
-In your main stylesheet:
-
-```sass
-@import 'bourbon/bourbon';
-@import 'neat/neat';
-```
-
-To update Neat files, run:
-
-```bash
 neat update
-```
-
-and to remove them:
-
-```bash
 neat remove
 ```
 
-Ruby on Rails
-===
+More information can be found in the [wiki](https://github.com/thoughtbot/neat/wiki/Command-Line-Interface).
 
-In your Gemfile:
-
-```bash
-gem 'neat'
-```
-
-After running `bundle install` you will be able to use Bourbon and Neat together.
-
-If you see this error `Bundler could not find compatible versions for gem "sass"` run:
-
-```bash
-bundle update sass
-```
-
-Within your `application.css.scss` file place the following:
-
-```sass
-@import 'bourbon';
-@import 'neat';
-```
-
-Getting started
-===
+## Using Neat
 
 First off, if you are planning to override the default grid settings (12 columns), it is recommended to create a `_grid-settings.scss` file for that purpose. Make sure to import it right *before* importing Neat:
 
 ```scss
-@import 'bourbon/bourbon'; // or 'bourbon' when in Rails
-@import 'grid-settings';
-@import 'neat/neat'; // or 'neat' when in Rails
+@import "bourbon/bourbon"; // or "bourbon" when in Rails
+@import "grid-settings";
+@import "neat/neat"; // or "neat" when in Rails
 ```
 
 In your newly created  `_grid-settings.scss`, import `neat-helpers` if you are planning to use `new-breakpoint()`, then define your new variables:
 
 ```scss
-@import 'neat/neat-helpers'; // or 'neat-helpers' when in Rails
+@import "neat/neat-helpers"; // or "neat-helpers" when in Rails
 
 // Change the grid settings
 $column: 90px;
@@ -124,7 +155,7 @@ div.element {
 }
 ```
 
-If the element's parent isn't the top-most container, you need to add the number of columns of the parent element to keep the right proportions:
+If the element’s parent isn’t the top-most container, you need to add the number of columns of the parent element to keep the right proportions:
 
 ```scss
 div.container {
@@ -167,41 +198,23 @@ By setting `$visual-grid` to `true`, you can display the base grid in the backgr
 
 The visual grid reflects the changes applied to the grid via the `new-breakpoint()` mixin, as long as the media contexts are defined *before* importing Neat.
 
-Browser support
-===
-- Firefox 3.5+
-- Safari 4.0+
-- Chrome 4.0+
-- Opera 9.5+
-- IE 9+ (Visual grid is IE10 only)
-- IE 8 with [selectivizr](http://selectivizr.com) (no `media()` support)
+## FAQ
 
-Frequently asked questions
-==========================
+#### How do I use `omega()` in a mobile-first workflow?
 
-##### How do I use `omega()` in a mobile-first workflow?
-
-Using `omega()` with an `nth-child` pseudo selector in a mobile-first workflow
-will cause the style to be applied to wider-viewport media queries as well. That
+Using `omega()` with an `nth-child` pseudo selector in a mobile-first workflow will cause the style to be applied to wider-viewport media queries as well. That
 is the cascading nature of CSS.
 
-One solution would be to provide an `omega-reset()` mixin that negates the
-effect of `omega()` on that specific `nth-child` pseudo selector. While this is
-often the most suggested solution, it is also a lazy hack that outputs ugly code
-and can quickly get out of hand in complex layouts. As a general rule, having to
-*undo* CSS styles is a sign of poor stylesheet architecture (More about
-[CSS code smells](http://csswizardry.com/2012/11/code-smells-in-css/)).
+One solution would be to provide an `omega-reset()` mixin that negates the effect of `omega()` on that specific `nth-child` pseudo selector. While this is
+often the most suggested solution, it is also a lazy hack that outputs ugly code and can quickly get out of hand in complex layouts. As a general rule, having to *undo* CSS styles is a sign of poor stylesheet architecture (more about [CSS code smells](http://csswizardry.com/2012/11/code-smells-in-css/)).
 
-The other, more elegant, solution is to use mutually exclusive media queries,
-also referred to as [media-query
-splitting](http://simurai.com/blog/2012/08/29/media-query-splitting/). This
-would guarantee that `omega()` styles are only applied where desired.
+The other, more elegant, solution is to use mutually exclusive media queries, also referred to as [media-query
+splitting](http://simurai.com/blog/2012/08/29/media-query-splitting). This would guarantee that `omega()` styles are only applied where desired.
 
 ```scss
 $first-breakpoint-value: 400px;
 $second-breakpoint-value: 700px;
-$medium-viewport: new-breakpoint(min-width em($first-breakpoint-value) max-width
-em($second-breakpoint-value));
+$medium-viewport: new-breakpoint(min-width em($first-breakpoint-value) max-width em($second-breakpoint-value));
 $large-viewport: new-breakpoint(min-width em($second-breakpoint-value + 1));
 
 .element {
@@ -217,44 +230,49 @@ $large-viewport: new-breakpoint(min-width em($second-breakpoint-value + 1));
 }
 ```
 
-If, for some reason, you still think that `omega-reset` is the only way you want to go,
-check out Josh Fry's
-[omega-reset](http://joshfry.me/notes/omega-reset-for-bourbon-neat/).
+If, for some reason, you still think that `omega-reset` is the only way you want to go, check out Josh Fry’s [omega-reset](http://joshfry.me/blog/2013/05/13/omega-reset-for-bourbon-neat).
 
-##### Why are the elements not properly aligned with the visual grid?
+#### Why are the elements not properly aligned with the visual grid?
 
-The visual grid is built using CSS gradients whose stops might contain decimal values depending on the default settings of your grid. In order to render the gradient, browsers round the pixel values since they can't deal with pixel fractions.
+The visual grid is built using CSS gradients whose stops might contain decimal values depending on the default settings of your grid. In order to render the gradient, browsers round the pixel values since they can’t deal with pixel fractions.
 
 As a result the viusal grid might be few pixels off in some browsers. The result is also inconsistent across browsers. For best results, preview your website on Firefox as it renders closest to the expected outcome.
 
 At this point, writing an internal rounding mechanism is not high priority.
 
+#### Framework X has this feature that Neat seems to be missing. Can you add it?
 
-##### Framework X has this feature that Neat seems to be missing. Can you add it?
+Unless you [open a pull request](https://github.com/thoughtbot/neat/compare/), the answer is most likely going to be no. Neat is lightweight and simple compared to other grid frameworks, and strives to remain so. We have plans for adding new features in future versions of the framework, but these will be most likely to support new ways of working with layouts on the Web, not patches to existing ones.
 
-Unless you [open a pull request](https://github.com/thoughtbot/neat/compare/), the answer is most likely going to be no. Neat is
-lightweight and simple compared to other grid frameworks, and strives to
-remain so. We have plans for adding new features in future versions of the
-framework, but these will be most likely to support new ways of working with
-layouts on the Web, not patches to existing ones.
+## Links
 
-Links
-=====
-
-- Read the [online documentation](http://neat.bourbon.io/docs/).
 - Add the docset to [Dash](http://kapeli.com/dash) 1.8+ (Preferences **>** Downloads **>** + *Add Docset Feed* **>** `http://neat.bourbon.io/docset/Neat.xml`)
-- Ask questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/neat). Don't forget to tag them `bourbon` and `neat`.
+- Ask questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/neat). Don’t forget to tag them `bourbon` and `neat`.
 - Suggest features or file bugs in [Issues](https://github.com/thoughtbot/neat/issues).
-- Read the [contribution guidelines](https://github.com/thoughtbot/neat/blob/master/CONTRIBUTING.md).
 - Join `#bourbon-neat` on `irc.freenode.net`.
 
+## Browser support
 
-Credits & License
-=================
+- Chrome 4.0+
+- Firefox 3.5+
+- Internet Explorer 9+ (visual grid is IE 10 only)
+- Internet Explorer 8 with [selectivizr](http://selectivizr.com) (no `media()` support)
+- Opera 9.5+
+- Safari 4.0+
+
+## The Bourbon family
+
+- [Bourbon](http://bourbon.io): A simple and lightweight mixin library for Sass
+- [Neat](http://neat.bourbon.io): A lightweight semantic grid framework for Sass and Bourbon
+- [Bitters](http://bitters.bourbon.io): Scaffold styles, variables and structure for Bourbon projects
+- [Refills](http://refills.bourbon.io): Prepackaged patterns and components, built on top of Bourbon, Bitters & Neat
+
+## Credits
 
 ![thoughtbot](http://thoughtbot.com/images/tm/logo.png)
 
-Bourbon is maintained and funded by [thoughtbot, inc](http://thoughtbot.com/). Follow [@thoughtbot](http://twitter.com/thoughtbot) on Twitter.
-Tweet your questions or suggestions to [@bourbonsass](https://twitter.com/bourbonsass) and while you’re at it follow us too.
+Neat is maintained and funded by [thoughtbot, inc](http://thoughtbot.com). Tweet your questions or suggestions to [@bourbonsass](https://twitter.com/bourbonsass) and while you’re at it follow us too.
 
-Bourbon Neat is Copyright © 2012-2014 thoughtbot. It is free software, and may be redistributed under the terms specified in the LICENSE file.
+## License
+
+Copyright © 2012–2014 [thoughtbot, inc](http://thoughtbot.com). Neat is free software, and may be redistributed under the terms specified in the [license](LICENSE.md).


### PR DESCRIPTION
- Make instructions more clear and succinct
- Better align with Bourbon README
- Use double prime marks in examples, per our guides
- Provide numbered instructions

In the future, I would like to tweak and bring clarity to the “Using Neat” section.

I’m also curious if the FAQ’s section would be better served as a Wiki page; thoughts?
