### PR TITLE
Adds not function for Libsass compatibility

### DIFF
--- a/app/assets/stylesheets/functions/_new-breakpoint.scss
+++ b/app/assets/stylesheets/functions/_new-breakpoint.scss
@@ -41,7 +41,7 @@
     $query: append($query, $total-columns);
   }
 
-  @if not-(belongs-to($query, $visual-grid-breakpoints)) {
+  @if is-not(belongs-to($query, $visual-grid-breakpoints)) {
     $visual-grid-breakpoints: append($visual-grid-breakpoints, $query, comma) !global;
   }
 

--- a/app/assets/stylesheets/functions/_new-breakpoint.scss
+++ b/app/assets/stylesheets/functions/_new-breakpoint.scss
@@ -41,7 +41,7 @@
     $query: append($query, $total-columns);
   }
 
-  @if not belongs-to($query, $visual-grid-breakpoints) {
+  @if not-(belongs-to($query, $visual-grid-breakpoints)) {
     $visual-grid-breakpoints: append($visual-grid-breakpoints, $query, comma) !global;
   }
 

--- a/app/assets/stylesheets/functions/_private.scss
+++ b/app/assets/stylesheets/functions/_private.scss
@@ -1,6 +1,6 @@
 // Not function for Libsass compatibility
 // https://github.com/sass/libsass/issues/368
-@function not-($value) {
+@function is-not($value) {
   @return if($value, false, true);
 }
 
@@ -11,11 +11,11 @@
 
 // Checks if an element belongs to a list or not
 @function belongs-to($tested-item, $list) {
-  @return not-(not-belongs-to($tested-item, $list));
+  @return is-not(not-belongs-to($tested-item, $list));
 }
 
 @function not-belongs-to($tested-item, $list) {
-  @return not-(index($list, $tested-item));
+  @return is-not(index($list, $tested-item));
 }
 
 // Contains display value

--- a/app/assets/stylesheets/functions/_private.scss
+++ b/app/assets/stylesheets/functions/_private.scss
@@ -1,23 +1,34 @@
+// Not function for Libsass compatibility
+// https://github.com/sass/libsass/issues/368
+@function not-($value) {
+  @return if($value, false, true);
+}
+
 // Checks if a number is even
 @function is-even($int) {
-  @return $int % 2 == 0
+  @return $int % 2 == 0;
 }
 
 // Checks if an element belongs to a list or not
 @function belongs-to($tested-item, $list) {
-  @return not not-belongs-to($tested-item, $list);
+  @return not-(not-belongs-to($tested-item, $list));
 }
 
 @function not-belongs-to($tested-item, $list) {
-  @return not index($list, $tested-item);
+  @return not-(index($list, $tested-item));
 }
 
 // Contains display value
 @function contains-display-value($query) {
-  @return belongs-to(table, $query)
-       or belongs-to(block, $query)
-       or belongs-to(inline-block, $query)
-       or belongs-to(inline, $query);
+  @if belongs-to(table, $query) {
+    @return belongs-to(table, $query);
+  } @else if belongs-to(block, $query) {
+    @return belongs-to(block, $query);
+  } @else if belongs-to(inline-block, $query) {
+    @return belongs-to(inline-block, $query);
+  } @else {
+    @return belongs-to(inline, $query);
+  }
 }
 
 // Parses the first argument of span-columns()

--- a/app/assets/stylesheets/functions/_private.scss
+++ b/app/assets/stylesheets/functions/_private.scss
@@ -20,15 +20,10 @@
 
 // Contains display value
 @function contains-display-value($query) {
-  @if belongs-to(table, $query) {
-    @return belongs-to(table, $query);
-  } @else if belongs-to(block, $query) {
-    @return belongs-to(block, $query);
-  } @else if belongs-to(inline-block, $query) {
-    @return belongs-to(inline-block, $query);
-  } @else {
-    @return belongs-to(inline, $query);
-  }
+  @return belongs-to(table, $query)
+       or belongs-to(block, $query)
+       or belongs-to(inline-block, $query)
+       or belongs-to(inline, $query);
 }
 
 // Parses the first argument of span-columns()

--- a/app/assets/stylesheets/grid/_media.scss
+++ b/app/assets/stylesheets/grid/_media.scss
@@ -68,7 +68,7 @@
     $default-grid-columns: $grid-columns;
     $grid-columns: $total-columns !global;
 
-    @if not-(is-even(length($query))) {
+    @if is-not(is-even(length($query))) {
       $grid-columns: nth($query, $loop-to) !global;
       $loop-to: $loop-to - 1;
     }

--- a/app/assets/stylesheets/grid/_media.scss
+++ b/app/assets/stylesheets/grid/_media.scss
@@ -68,7 +68,7 @@
     $default-grid-columns: $grid-columns;
     $grid-columns: $total-columns !global;
 
-    @if not is-even(length($query)) {
+    @if not-(is-even(length($query))) {
       $grid-columns: nth($query, $loop-to) !global;
       $loop-to: $loop-to - 1;
     }


### PR DESCRIPTION
I don’t think ` not ` is safe to use right now due to this missing feature in Libsass https://github.com/sass/libsass/issues/368

I’ve added a `not-()` function that should allow it to return the correct result on both until that issue is closed. I’m not sure if that’s the right syntax necessarily, so I’m happy to make changes based on feedback.