### PR TITLE
Remove not-belongs-to as not belongs-to is equivalent

### DIFF
--- a/app/assets/stylesheets/functions/_private.scss
+++ b/app/assets/stylesheets/functions/_private.scss
@@ -5,11 +5,7 @@
 
 // Checks if an element belongs to a list or not
 @function belongs-to($tested-item, $list) {
-  @return not not-belongs-to($tested-item, $list);
-}
-
-@function not-belongs-to($tested-item, $list) {
-  @return not index($list, $tested-item);
+  @return not not index($list, $tested-item);
 }
 
 // Contains display value


### PR DESCRIPTION
Added in #220. I don't think this is necessary as `not-belongs-to` can be simply called as `not belongs-to` [like here](https://github.com/thoughtbot/neat/blob/master/app/assets/stylesheets/functions/_new-breakpoint.scss#L44). Whereas in `belongs-to` it's now clear that you're calling `not not` in front of index. As sass community picks up `not not` as JS `!!` this make the code more self explanatory.

/cc @kaishin.
