### PR TITLE
Fixed non-ASCII characters issue

### DIFF
--- a/app/assets/stylesheets/grid/_row.scss
+++ b/app/assets/stylesheets/grid/_row.scss
@@ -1,4 +1,4 @@
-/// Designates the element as a row of columns in the grid layout. It clears the floats on the element and sets its display property. Rows can't be nested, but there can be more than one row element—with different display properties—per layout.
+/// Designates the element as a row of columns in the grid layout. It clears the floats on the element and sets its display property. Rows can't be nested, but there can be more than one row element-with different display properties-per layout.
 ///
 /// @param {String} $display (default)
 ///  Sets the display property of the element and the display context that will be used by its children. Can be `block` or `table`.


### PR DESCRIPTION
I'm developing an AngularJS project using `gulp` with `gulp-ruby-sass` in order to compile all the `scss` files. Everything worked on my machine (I have a MackBook Air, but I'm developing using Vagrant VM with Ubuntu), but when I tried to deploy it on Heroku I got:

```
Error in plugin 'gulp-ruby-sass'
Message:
    error /tmp/build_abab9a195c7b2366a08c918fe16ba4d5/bower_components/neat/app/assets/stylesheets/grid/_row.scss (Line 1: Invalid US-ASCII character "\xE2")
```

Here is the full output: https://gist.github.com/willian/673ce685f5200a93ac2d

The problem is with some non-ASCII characters in some files. I'm creating this PR to fix those files by removing non-ASCII characters.

If you want to know how I found those characters, I open the files on my Vim and I executed `/[^\x00-\x7F]`

PS.: I'm sorry, I updated the version because I wasn't able to test only by pointing to a commit hash.
