### PR TITLE
Update direction-context documentation

### DIFF
--- a/app/assets/stylesheets/grid/_direction-context.scss
+++ b/app/assets/stylesheets/grid/_direction-context.scss
@@ -4,7 +4,7 @@
 ///   Layout direction to be used within the block. Can be `left-to-right` or `right-to-left`.
 ///
 /// @example scss - Usage
-///   @include direction(right-to-left) {
+///   @include direction-context(right-to-left) {
 ///    .right-to-left-block {
 ///      @include span-columns(6);
 ///     }


### PR DESCRIPTION
The example is using `direction` instead of `direction-context`.