### PR TITLE
Specify CSS @charset

### DIFF
--- a/app/assets/stylesheets/functions/_new-breakpoint.scss
+++ b/app/assets/stylesheets/functions/_new-breakpoint.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Returns a media context (media query / grid context) that can be stored in a variable and passed to `media()` as a single-keyword argument. Media contexts defined using `new-breakpoint` are used by the visual grid, as long as they are defined before importing Neat.
 ///
 /// @param {List} $query

--- a/app/assets/stylesheets/grid/_box-sizing.scss
+++ b/app/assets/stylesheets/grid/_box-sizing.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 @if $border-box-sizing == true {
   html { // http://bit.ly/1qk2tVR
     @include box-sizing(border-box);

--- a/app/assets/stylesheets/grid/_direction-context.scss
+++ b/app/assets/stylesheets/grid/_direction-context.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Changes the direction property used by other mixins called in the code block argument.
 ///
 /// @param {String} $direction (left-to-right)

--- a/app/assets/stylesheets/grid/_display-context.scss
+++ b/app/assets/stylesheets/grid/_display-context.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Changes the display property used by other mixins called in the code block argument.
 ///
 /// @param {String} $display (block)

--- a/app/assets/stylesheets/grid/_fill-parent.scss
+++ b/app/assets/stylesheets/grid/_fill-parent.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Forces the element to fill its parent container.
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_media.scss
+++ b/app/assets/stylesheets/grid/_media.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Outputs a media-query block with an optional grid context (the total number of columns used in the grid).
 ///
 /// @param {List} $query

--- a/app/assets/stylesheets/grid/_omega.scss
+++ b/app/assets/stylesheets/grid/_omega.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Removes the element's gutter margin, regardless of its position in the grid hierarchy or display property. It can target a specific element, or every `nth-child` occurrence. Works only with `block` layouts.
 ///
 /// @param {List} $query (block)

--- a/app/assets/stylesheets/grid/_outer-container.scss
+++ b/app/assets/stylesheets/grid/_outer-container.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Makes an element a outer container by centring it in the viewport, clearing its floats, and setting its `max-width`.
 /// Although optional, using `outer-container` is recommended. The mixin can be called on more than one element per page, as long as they are not nested.
 ///

--- a/app/assets/stylesheets/grid/_pad.scss
+++ b/app/assets/stylesheets/grid/_pad.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Adds padding to the element.
 ///
 /// @param {List} $padding (flex-gutter())

--- a/app/assets/stylesheets/grid/_row.scss
+++ b/app/assets/stylesheets/grid/_row.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Designates the element as a row of columns in the grid layout. It clears the floats on the element and sets its display property. Rows can't be nested, but there can be more than one row element—with different display properties—per layout.
 ///
 /// @param {String} $display (default)
@@ -48,4 +50,3 @@
     $container-display-table: false !global;
   }
 }
-

--- a/app/assets/stylesheets/grid/_shift.scss
+++ b/app/assets/stylesheets/grid/_shift.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Translates an element horizontally by a number of columns. Positive arguments shift the element to the active layout direction, while negative ones shift it to the opposite direction.
 ///
 /// @param {Number (unitless)} $n-columns (1)

--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Specifies the number of columns an element should span. If the selector is nested the number of columns of its parent element should be passed as an argument as well.
 ///
 /// @param {List} $span

--- a/app/assets/stylesheets/grid/_to-deprecate.scss
+++ b/app/assets/stylesheets/grid/_to-deprecate.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 @mixin breakpoint($query:$feature $value $columns, $total-columns: $grid-columns) {
   @include -neat-warn("The breakpoint() mixin was renamed to media() in Neat 1.0. Please update your project with the new syntax before the next version bump.");
 

--- a/app/assets/stylesheets/grid/_visual-grid.scss
+++ b/app/assets/stylesheets/grid/_visual-grid.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 @mixin grid-column-gradient($values...) {
   background-image: -webkit-linear-gradient(left, $values);
   background-image: -moz-linear-gradient(left, $values);

--- a/app/assets/stylesheets/settings/_disable-warnings.scss
+++ b/app/assets/stylesheets/settings/_disable-warnings.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Disable all deprecation warnings. Defaults to `false`. Set with a `!global` flag.
 ///
 /// @type Bool

--- a/app/assets/stylesheets/settings/_grid.scss
+++ b/app/assets/stylesheets/settings/_grid.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Sets the relative width of a single grid column. The unit used should be the same one used to define `$gutter`. To learn more about golden-ratio() see [Bourbon docs](http://bourbon.io/docs/#golden-ratio). Set with a `!global` flag.
 ///
 /// @type Number (Unit)

--- a/app/assets/stylesheets/settings/_visual-grid.scss
+++ b/app/assets/stylesheets/settings/_visual-grid.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 /// Displays the visual grid when set to true. The overlaid grid may be few pixels off depending on the browser's rendering engine and pixel rounding algorithm. Set with the `!global` flag.
 ///
 /// @type Bool


### PR DESCRIPTION
Per the discussion on [this PR](https://github.com/thoughtbot/neat/pull/270) and now that our documentation is inline, we need to specify the CSS `@charset` to be able to use things like en and em dashes, etc…
