### PR TITLE
Include the step to install the neat library

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,16 @@ For command line help, visit our wiki page on Neat’s [command line interface](
   bundle update sass
   ```
 
-3. Import Neat in your `application.css.scss`, after Bourbon:
+3. Install the Neat library into the current directory:
+
+  ```bash
+  bourbon install # if not already installed
+  ```
+  ```bash
+  neat install
+  ```
+
+4.  Import Neat in your `application.css.scss`, after Bourbon:
 
   ```scss
   @import "bourbon";


### PR DESCRIPTION
As part of the Installation for Ruby on Rails; causes confusion when not present.

Ref: http://stackoverflow.com/questions/27646020/neat-gem-not-installed-correctly/27647313?noredirect=1#comment43717181_27647313