### PR TITLE
Remove unneeded install step for Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,7 @@ For command line help, visit our wiki page on Neat’s [command line interface](
   bundle update sass
   ```
 
-3. Install the Neat library into the current directory:
-
-  ```bash
-  bourbon install # if not already installed
-  ```
-  ```bash
-  neat install
-  ```
-
-4.  Import Neat in your `application.css.scss`, after Bourbon:
+3.  Import Neat in your `application.scss`, after Bourbon:
 
   ```scss
   @import "bourbon";


### PR DESCRIPTION
- This step is not needed for a Rails install (although [it _is_ needed](https://github.com/thoughtbot/neat/pull/289) for a non-Rails install)
- Change reference to main manifest file from `application.css.scss` to `application.scss` because the `.css` in not needed