### PR TITLE
Remove prefixing on box-sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,12 @@ Unless you [open a pull request](https://github.com/thoughtbot/neat/compare/), t
 
 ## Browser support
 
-- Chrome 4.0+
-- Firefox 3.5+
+- Chrome 10+
+- Firefox 29+
 - Internet Explorer 9+ (visual grid is IE 10 only)
 - Internet Explorer 8 with [selectivizr](http://selectivizr.com) (no `media()` support)
 - Opera 9.5+
-- Safari 4.0+
+- Safari 5.1+
 
 ## The Bourbon family
 

--- a/app/assets/stylesheets/grid/_box-sizing.scss
+++ b/app/assets/stylesheets/grid/_box-sizing.scss
@@ -2,14 +2,14 @@
 
 @if $border-box-sizing == true {
   html { // http://bit.ly/1qk2tVR
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   * {
     &,
-    &:before,
-    &:after {
-      @include box-sizing(inherit);
+    &::after,
+    &::before {
+      box-sizing: inherit;
     }
   }
 }

--- a/app/assets/stylesheets/grid/_fill-parent.scss
+++ b/app/assets/stylesheets/grid/_fill-parent.scss
@@ -10,8 +10,6 @@
 /// @example css - CSS Output
 ///   .element {
 ///     width: 100%;
-///     -webkit-box-sizing: border-box;
-///     -moz-box-sizing: border-box;
 ///     box-sizing: border-box;
 ///   }
 
@@ -19,6 +17,6 @@
   width: 100%;
 
   @if $border-box-sizing == false {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 }

--- a/app/assets/stylesheets/settings/_grid.scss
+++ b/app/assets/stylesheets/settings/_grid.scss
@@ -30,13 +30,9 @@ $max-width: em(1088) !default;
 ///
 /// @example css - CSS Output
 ///   html {
-///     -webkit-box-sizing: border-box;
-///     -moz-box-sizing: border-box;
 ///     box-sizing: border-box; }
 ///
-///   *, *:before, *:after {
-///     -webkit-box-sizing: inherit;
-///     -moz-box-sizing: inherit;
+///   *, *::after, *::before {
 ///     box-sizing: inherit;
 ///   }
 

--- a/spec/neat/default_spec.rb
+++ b/spec/neat/default_spec.rb
@@ -10,6 +10,6 @@ describe "By default" do
   end
 
   it "sets sizing on the global selector to inherit" do
-    expect("*:after").to have_rule("box-sizing: inherit")
+    expect("*::after").to have_rule("box-sizing: inherit")
   end
 end


### PR DESCRIPTION
Reference: [Can I Use](http://caniuse.com/#feat=css3-boxsizing)

Also [planning to deprecate](https://github.com/thoughtbot/bourbon/pull/568) the box sizing mixin in Bourbon.