### PR TITLE
Add note about `span-columns` accepting decimals

### DIFF
--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -9,6 +9,8 @@
 ///
 ///   The values can be separated with any string such as `of`, `/`, etc.
 ///
+///   `$columns` also accepts decimals for when it's necessary to break out of the standard grid. E.g. Passing `2.4` in a standard 12 column grid will divide the row into 5 columns.
+///
 /// @param {String} $display (block)
 ///   Sets the display property of the element. By default it sets the display propert of the element to `block`.
 ///


### PR DESCRIPTION
After trying numerous more complex workarounds for a displaying number of columns that doesn't evenly divide into the grid I finally stumbled upon this: http://thisbythem.com/blog/odd-number-in-even-columns-with-neat/.

I figured explicitly calling out the decimal support in the dos could help other users in similar situations.