### PR TITLE
Add package info for npm

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,20 +1,44 @@
 {
   "name": "neat",
-  "homepage": "http://neat.bourbon.io/",
+  "description": "A lightweight, semantic grid framework built with Bourbon",
+  "version": "1.7.1",
   "main": "app/assets/stylesheets/_neat.scss",
+  "license": "MIT",
   "ignore": [
-    "bin",
-    "lib",
-    ".gitignore",
+    "**/.*",
+    "CONTRIBUTING.md",
     "Gemfile",
     "Gemfile.lock",
-    "Rakefile",
-    "neat.gemspec",
-    "CONTRIBUTING.md",
     "NEWS.md",
-    "test",
-    "spec"
+    "Rakefile",
+    "bin",
+    "lib",
+    "neat.gemspec",
+    "sache.json",
+    "spec",
+    "test"
   ],
+  "keywords": [
+    "bourbon",
+    "columns",
+    "grid",
+    "layout",
+    "media",
+    "media-queries",
+    "neat",
+    "queries",
+    "sass",
+    "scss",
+    "semantic"
+  ],
+  "authors": [
+    "thoughtbot (http://thoughtbot.com)"
+  ],
+  "homepage": "http://neat.bourbon.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thoughtbot/neat.git"
+  },
   "dependencies": {
     "bourbon": ">=4.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "bourbon-neat",
+  "version": "1.7.1",
+  "description": "A lightweight, semantic grid framework built with Bourbon",
+  "keywords": [
+    "bourbon",
+    "columns",
+    "grid",
+    "layout",
+    "media",
+    "media-queries",
+    "neat",
+    "queries",
+    "sass",
+    "scss",
+    "semantic"
+  ],
+  "homepage": "http://neat.bourbon.io",
+  "bugs": {
+    "url": "https://github.com/thoughtbot/neat/issues"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "thoughtbot",
+    "url": "http://thoughtbot.com"
+  },
+  "main": "app/assets/stylesheets/_neat.scss",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thoughtbot/neat.git"
+  },
+  "scripts": {
+    "test": "echo \"No test specified\""
+  }
+}

--- a/sache.json
+++ b/sache.json
@@ -1,5 +1,5 @@
 {
   "name": "Neat",
-  "description": "A lightweight, semantic grid framework built on top of Bourbon",
-  "tags": ["neat", "grid", "layout", "columns", "semantic", "media-queries", "media", "queries", "bourbon"]
+  "description": "A lightweight, semantic grid framework built with Bourbon",
+  "tags": ["bourbon", "columns", "grid", "layout", "media", "media-queries", "neat", "queries", "sass", "scss", "semantic"]
 }


### PR DESCRIPTION
`neat` is [taken]() on npm, so we’ll have to settle for another name; I thought `bourbon-neat` would be god.

- Unify `bower.json` and `sache.json` (mostly :abc:’ing tag lists)