### PR TITLE
Decouple Neat from Bourbon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Gitter](http://img.shields.io/badge/gitter-neat-ae3dd2.svg?style=flat)](https://gitter.im/thoughtbot/neat)
 [![Stack Overflow](http://img.shields.io/badge/stack%20overflow-neat-ae3dd2.svg?style=flat)](http://stackoverflow.com/questions/tagged/neat)
 
-## A lightweight, semantic grid framework built with Bourbon
+## A lightweight, semantic grid framework
 
-Neat is a fluid grid framework built with [Bourbon](https://github.com/thoughtbot/bourbon) with the aim of being easy enough to use out of the box and flexible enough to customize down the road.
+Neat is a fluid grid framework with the aim of being easy enough to use out of the box and flexible enough to customize down the road.
 
 - **[Demo](http://neat.bourbon.io)**
 - **[Documentation](http://thoughtbot.github.io/neat-docs/latest)**
@@ -16,7 +16,6 @@ Neat is a fluid grid framework built with [Bourbon](https://github.com/thoughtbo
 ## Requirements
 
 - [Sass](https://github.com/sass/sass) 3.3+
-- [Bourbon](https://github.com/thoughtbot/bourbon) 4.0+
 - :warning: If you need **Sass 3.2 support**, you should [use Neat 1.5.1](#installing-older-versions-of-neat)
 
 ## Installation
@@ -36,23 +35,16 @@ For command line help, visit our wiki page on Neat’s [command line interface](
   ```bash
   gem install sass # or gem update sass
   ```
-  ```bash
-  gem install bourbon # or gem update bourbon
-  ```
 
 3. Install the Neat library into the current directory:
 
   ```bash
-  bourbon install # if not already installed
-  ```
-  ```bash
   neat install
   ```
 
-4. Import Neat in your stylesheet, after Bourbon:
+4. Import Neat in your stylesheet:
 
   ```scss
-  @import "bourbon/bourbon";
   @import "neat/neat";
   ```
 
@@ -78,10 +70,9 @@ For command line help, visit our wiki page on Neat’s [command line interface](
   bundle update sass
   ```
 
-3.  Import Neat in your `application.scss`, after Bourbon:
+3.  Import Neat in your `application.scss`:
 
   ```scss
-  @import "bourbon";
   @import "neat";
   ```
 
@@ -108,7 +99,6 @@ For command line help, visit our wiki page on Neat’s [command line interface](
 First off, if you are planning to override the default grid settings (12 columns), it is recommended to create a `_grid-settings.scss` file for that purpose. Make sure to import it right *before* importing Neat:
 
 ```scss
-@import "bourbon/bourbon"; // or "bourbon" when in Rails
 @import "grid-settings";
 @import "neat/neat"; // or "neat" when in Rails
 ```
@@ -122,7 +112,7 @@ In your newly created  `_grid-settings.scss`, import `neat-helpers` if you are p
 $column: 90px;
 $gutter: 30px;
 $grid-columns: 10;
-$max-width: em(1088);
+$max-width: 1088px;
 
 // Define your breakpoints
 $tablet: new-breakpoint(max-width 768px 8);
@@ -246,7 +236,7 @@ Unless you [open a pull request](https://github.com/thoughtbot/neat/compare/), t
 ## The Bourbon family
 
 - [Bourbon](https://github.com/thoughtbot/bourbon): A simple and lightweight mixin library for Sass
-- [Neat](https://github.com/thoughtbot/neat): A lightweight semantic grid framework for Sass and Bourbon
+- [Neat](https://github.com/thoughtbot/neat): A lightweight semantic grid framework for Sass
 - [Bitters](https://github.com/thoughtbot/bitters): Scaffold styles, variables and structure for Bourbon projects
 - [Refills](https://github.com/thoughtbot/refills): Prepackaged patterns and components built with Bourbon, Neat and Bitters
 

--- a/app/assets/stylesheets/_neat-helpers.scss
+++ b/app/assets/stylesheets/_neat-helpers.scss
@@ -2,6 +2,9 @@
 @import "functions/private";
 @import "functions/new-breakpoint";
 
+// Mixins
+@import "mixins/clearfix";
+
 // Settings
 @import "settings/grid";
 @import "settings/visual-grid";

--- a/app/assets/stylesheets/mixins/_clearfix.scss
+++ b/app/assets/stylesheets/mixins/_clearfix.scss
@@ -1,0 +1,7 @@
+@mixin clearfix {
+  &::after {
+    clear: both;
+    content: "";
+    display: table;
+  }
+}

--- a/app/assets/stylesheets/settings/_grid.scss
+++ b/app/assets/stylesheets/settings/_grid.scss
@@ -4,13 +4,13 @@
 ///
 /// @type Number (Unit)
 
-$column: modular-scale(3, 1em, $golden) !default;
+$column: 90px !default;
 
 /// Sets the relative width of a single grid gutter. The unit used should be the same one used to define `$column`. To learn more about modular-scale() see [Bourbon docs](http://bourbon.io/docs/#modular-scale). Set with the `!global` flag.
 ///
 /// @type Number (Unit)
 
-$gutter: modular-scale(1, 1em, $golden) !default;
+$gutter: 30px !default;
 
 /// Sets the total number of columns in the grid. Its value can be overridden inside a media query using the `media()` mixin. Set with the `!global` flag.
 ///
@@ -18,11 +18,11 @@ $gutter: modular-scale(1, 1em, $golden) !default;
 
 $grid-columns: 12 !default;
 
-/// Sets the max-width property of the element that includes `outer-container()`. To learn more about `em()` see [Bourbon docs](http://bourbon.io/docs/#px-to-em). Set with the `!global` flag.
+/// Sets the max-width property of the element that includes `outer-container()`. Set with the `!global` flag.
 ///
 /// @type Number (Unit)
 ///
-$max-width: em(1088) !default;
+$max-width: 1088px !default;
 
 /// When set to true, it sets the box-sizing property of all elements to `border-box`. Set with a `!global` flag.
 ///


### PR DESCRIPTION
I think decoupling Neat from Bourbon will have a few big positives:

* Expand Neat's potential user base
* Simplified install of Neat
* Clearer docs (no more `bourbon` before `grid_settings` before `neat` confusion)