### PR TITLE
Update parameter default syntax for Sassdoc

### DIFF
--- a/app/assets/stylesheets/functions/_new-breakpoint.scss
+++ b/app/assets/stylesheets/functions/_new-breakpoint.scss
@@ -9,7 +9,7 @@
 ///
 ///   The number of total columns in the grid can be set by passing `$columns` at the end of the list (overrides `$total-columns`). For a list of valid values for `$feature`, click [here](http://www.w3.org/TR/css3-mediaqueries/#media1).
 ///
-/// @param {Number (unitless)} $total-columns ($grid-columns)
+/// @param {Number (unitless)} $total-columns [$grid-columns]
 ///   - Number of columns to use in the new grid context. Can be set as a shorthand in the first parameter.
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_direction-context.scss
+++ b/app/assets/stylesheets/grid/_direction-context.scss
@@ -2,7 +2,7 @@
 
 /// Changes the direction property used by other mixins called in the code block argument.
 ///
-/// @param {String} $direction (left-to-right)
+/// @param {String} $direction [left-to-right]
 ///   Layout direction to be used within the block. Can be `left-to-right` or `right-to-left`.
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_display-context.scss
+++ b/app/assets/stylesheets/grid/_display-context.scss
@@ -2,7 +2,7 @@
 
 /// Changes the display property used by other mixins called in the code block argument.
 ///
-/// @param {String} $display (block)
+/// @param {String} $display [block]
 ///   Display value to be used within the block. Can be `table` or `block`.
 ///
 /// @example scss

--- a/app/assets/stylesheets/grid/_media.scss
+++ b/app/assets/stylesheets/grid/_media.scss
@@ -11,7 +11,7 @@
 ///   The number of total columns in the grid can be set by passing `$columns` at the end of the list (overrides `$total-columns`).
 ///
 ///
-/// @param {Number (unitless)} $total-columns ($grid-columns)
+/// @param {Number (unitless)} $total-columns [$grid-columns]
 ///   - Number of columns to use in the new grid context. Can be set as a shorthand in the first parameter.
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_omega.scss
+++ b/app/assets/stylesheets/grid/_omega.scss
@@ -2,7 +2,7 @@
 
 /// Removes the element's gutter margin, regardless of its position in the grid hierarchy or display property. It can target a specific element, or every `nth-child` occurrence. Works only with `block` layouts.
 ///
-/// @param {List} $query (block)
+/// @param {List} $query [block]
 ///   List of arguments. Supported arguments are `nth-child` selectors (targets a specific pseudo element) and `auto` (targets `last-child`).
 ///
 ///   When passed an `nth-child` argument of type `*n` with `block` display, the omega mixin automatically adds a clear to the `*n+1` th element. Note that composite arguments such as `2n+1` do not support this feature.

--- a/app/assets/stylesheets/grid/_outer-container.scss
+++ b/app/assets/stylesheets/grid/_outer-container.scss
@@ -3,7 +3,7 @@
 /// Makes an element a outer container by centring it in the viewport, clearing its floats, and setting its `max-width`.
 /// Although optional, using `outer-container` is recommended. The mixin can be called on more than one element per page, as long as they are not nested.
 ///
-/// @param {Number (unit)} $local-max-width ($max-width)
+/// @param {Number [unit]} $local-max-width [$max-width]
 ///   Max width to be applied to the element. Can be a percentage or a measure.
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_pad.scss
+++ b/app/assets/stylesheets/grid/_pad.scss
@@ -2,7 +2,7 @@
 
 /// Adds padding to the element.
 ///
-/// @param {List} $padding (flex-gutter())
+/// @param {List} $padding [flex-gutter()]
 ///   A list of padding value(s) to use. Passing `default` in the list will result in using the gutter width as a padding value.
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_row.scss
+++ b/app/assets/stylesheets/grid/_row.scss
@@ -2,10 +2,10 @@
 
 /// Designates the element as a row of columns in the grid layout. It clears the floats on the element and sets its display property. Rows can't be nested, but there can be more than one row element—with different display properties—per layout.
 ///
-/// @param {String} $display (default)
+/// @param {String} $display [default]
 ///  Sets the display property of the element and the display context that will be used by its children. Can be `block` or `table`.
 ///
-/// @param {String} $direction ($default-layout-direction)
+/// @param {String} $direction [$default-layout-direction]
 ///  Sets the layout direction. Can be `LTR` (left-to-right) or `RTL` (right-to-left).
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_shift.scss
+++ b/app/assets/stylesheets/grid/_shift.scss
@@ -2,7 +2,7 @@
 
 /// Translates an element horizontally by a number of columns. Positive arguments shift the element to the active layout direction, while negative ones shift it to the opposite direction.
 ///
-/// @param {Number (unitless)} $n-columns (1)
+/// @param {Number (unitless)} $n-columns [1]
 ///   Number of columns by which the element shifts.
 ///
 /// @example scss - Usage

--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -11,7 +11,7 @@
 ///
 ///   `$columns` also accepts decimals for when it's necessary to break out of the standard grid. E.g. Passing `2.4` in a standard 12 column grid will divide the row into 5 columns.
 ///
-/// @param {String} $display (block)
+/// @param {String} $display [block]
 ///   Sets the display property of the element. By default it sets the display propert of the element to `block`.
 ///
 ///   If passed `block-collapse`, it also removes the margin gutter by adding it to the element width.


### PR DESCRIPTION
The syntax has changed from (default) to [default] as of Sassdoc 2.0