### PR TITLE
Remove em() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In your newly created  `_grid-settings.scss`, import `neat-helpers` if you are p
 $column: 90px;
 $gutter: 30px;
 $grid-columns: 10;
-$max-width: em(1088);
+$max-width: 1200px;
 
 // Define your breakpoints
 $tablet: new-breakpoint(max-width 768px 8);
@@ -207,8 +207,8 @@ splitting](http://simurai.com/blog/2012/08/29/media-query-splitting). This would
 ```scss
 $first-breakpoint-value: 400px;
 $second-breakpoint-value: 700px;
-$medium-viewport: new-breakpoint(min-width em($first-breakpoint-value) max-width em($second-breakpoint-value));
-$large-viewport: new-breakpoint(min-width em($second-breakpoint-value + 1));
+$medium-viewport: new-breakpoint(min-width $first-breakpoint-value max-width $second-breakpoint-value);
+$large-viewport: new-breakpoint(min-width $second-breakpoint-value + 1);
 
 .element {
   @include media($medium-viewport) {

--- a/app/assets/stylesheets/settings/_grid.scss
+++ b/app/assets/stylesheets/settings/_grid.scss
@@ -1,12 +1,12 @@
 @charset "UTF-8";
 
-/// Sets the relative width of a single grid column. The unit used should be the same one used to define `$gutter`. To learn more about modular-scale() see [Bourbon docs](http://bourbon.io/docs/#modular-scale). Set with a `!global` flag.
+/// Sets the relative width of a single grid column. The unit used should be the same one used to define `$gutter`. To learn more about `modular-scale()` see [Bourbon docs](http://bourbon.io/docs/#modular-scale). Set with a `!global` flag.
 ///
 /// @type Number (Unit)
 
 $column: modular-scale(3, 1em, $golden) !default;
 
-/// Sets the relative width of a single grid gutter. The unit used should be the same one used to define `$column`. To learn more about modular-scale() see [Bourbon docs](http://bourbon.io/docs/#modular-scale). Set with the `!global` flag.
+/// Sets the relative width of a single grid gutter. The unit used should be the same one used to define `$column`. To learn more about `modular-scale()` see [Bourbon docs](http://bourbon.io/docs/#modular-scale). Set with the `!global` flag.
 ///
 /// @type Number (Unit)
 

--- a/app/assets/stylesheets/settings/_grid.scss
+++ b/app/assets/stylesheets/settings/_grid.scss
@@ -18,11 +18,11 @@ $gutter: modular-scale(1, 1em, $golden) !default;
 
 $grid-columns: 12 !default;
 
-/// Sets the max-width property of the element that includes `outer-container()`. To learn more about `em()` see [Bourbon docs](http://bourbon.io/docs/#px-to-em). Set with the `!global` flag.
+/// Sets the max-width property of the element that includes `outer-container()`. Set with the `!global` flag.
 ///
 /// @type Number (Unit)
 ///
-$max-width: em(1088) !default;
+$max-width: 1200px !default;
 
 /// When set to true, it sets the box-sizing property of all elements to `border-box`. Set with a `!global` flag.
 ///


### PR DESCRIPTION
Per [this discussion](https://github.com/thoughtbot/bourbon/issues/691) over on Bourbon, we’ll be removing the `em()` function. This PR removes the use of it from Neat. It really wasn’t doing very much, any way.

I made up `1200px` and am open to that being something else.