### PR TITLE
Add support for alternate omega selectors

### DIFF
--- a/app/assets/stylesheets/grid/_omega.scss
+++ b/app/assets/stylesheets/grid/_omega.scss
@@ -31,7 +31,7 @@
 ///     clear: left;
 ///   }
 
-@mixin omega($query: block, $direction: default) {
+@mixin omega($query: block, $direction: default, $selector: nth-child) {
   $table: belongs-to(table, $query);
   $auto: belongs-to(auto, $query);
 
@@ -57,7 +57,7 @@
     }
 
     @else {
-      @include nth-child($query, $direction);
+      @include nth-child($query, $direction, $selector);
     }
   } @else if length($query) == 2 {
     @if $auto {
@@ -65,22 +65,22 @@
         margin-#{$direction}: 0;
       }
     } @else {
-      @include nth-child(nth($query, 1), $direction);
+      @include nth-child(nth($query, 1), $direction, $selector);
     }
   } @else {
     @include -neat-warn("Too many arguments passed to the omega() mixin.");
   }
 }
 
-@mixin nth-child($query, $direction) {
+@mixin nth-child($query, $direction, $selector) {
   $opposite-direction: get-opposite-direction($direction);
 
-  &:nth-child(#{$query}) {
+  &:#{$selector}(#{$query}) {
     margin-#{$direction}: 0;
   }
 
   @if type-of($query) == number and unit($query) == "n" {
-    &:nth-child(#{$query}+1) {
+    &:#{$selector}(#{$query}+1) {
       clear: $opposite-direction;
     }
   }

--- a/spec/neat/omega_spec.rb
+++ b/spec/neat/omega_spec.rb
@@ -21,9 +21,21 @@ describe "@include omega()" do
     end
   end
 
+  context "with argument for nth-of-type" do
+    it "removes right margin of nth-of-type(2n)" do
+      selector = ".omega-nth-of-type:nth-of-type(2n)"
+      expect(selector).to have_rule("margin-right: 0")
+    end
+
+    it "adds clear to nth-of-type(2n+1)" do
+      expect(".omega-nth-of-type:nth-of-type(2n+1)").to have_rule("clear: left")
+    end
+  end
+
   context "with argument ('4n+1')" do
     it "removes right margin of nth-child(4n+1)" do
-      expect(".omega-complex-nth:nth-child(4n+1)").to have_rule("margin-right: 0")
+      selector = ".omega-complex-nth:nth-child(4n+1)"
+      expect(selector).to have_rule("margin-right: 0")
     end
   end
 

--- a/test/omega.scss
+++ b/test/omega.scss
@@ -12,6 +12,10 @@
   @include omega("4n+1");
 }
 
+.omega-nth-of-type {
+  @include omega(2n, default, nth-of-type);
+}
+
 section {
   @include row($direction: RTL);
 


### PR DESCRIPTION
Fixes #318.

iOS8 has an apparent bug which breaks support for `nth-child`. The common workaround for this is to use `nth-of-type` instead. This adds support to specify the selector you want to use (defaults to `nth-child`).

I'm not sure if I like adding something like this for an obvious bug in a specific browser, but here is the proposed solution. What do you think?