### PR TITLE
Adds an npm ignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,17 @@
+bin/
+lib/
+spec/
+test/
+.gitignore
+.rspec
+.scss-lint.yml
+.sass-cache
+.travis.yml
+bower.json
+CONTRIBUTING.md
+Gemfile
+Gemfile.lock
+neat.gemspec
+NEWS.md
+Rakefile
+sache.json


### PR DESCRIPTION
If you install through npm right now, you get a bunch of files that you don’t need.

This PR adds an `.npmignore` file similar to Bourbon’s, so you only install the things you need and there no possibility of accidentally having the tests pre-compiling and breaking.