### PR TITLE
Update row() to check for display-context

### DIFF
--- a/app/assets/stylesheets/grid/_row.scss
+++ b/app/assets/stylesheets/grid/_row.scss
@@ -32,7 +32,9 @@
 
   $layout-direction: $direction !global;
 
-  @if $display == table {
+  $display-table: is-display-table($container-display-table, $display);
+
+  @if $display-table {
     display: table;
     @include fill-parent;
     table-layout: fixed;


### PR DESCRIPTION
the @mixin row() doesn't check for the display-context like other mixins do. Changing these lines puts the mixin in line with, for examble, span-columns() which checks the context and proceeds accordingly.

From
https://github.com/thoughtbot/neat/issues/338