### PR TITLE
Changes to the documentation for outer-container.

### DIFF
--- a/app/assets/stylesheets/grid/_outer-container.scss
+++ b/app/assets/stylesheets/grid/_outer-container.scss
@@ -13,19 +13,15 @@
 ///
 /// @example css - CSS Output
 ///   .element {
-///     *zoom: 1;
 ///     max-width: 100%;
 ///     margin-left: auto;
 ///     margin-right: auto;
 ///   }
 ///
-///   .element:before, .element:after {
-///     content: " ";
-///     display: table;
-///   }
-///
-///   .element:after {
+///   .element::after {
 ///     clear: both;
+///     content: "";
+///     display: table;
 ///   }
 
 @mixin outer-container($local-max-width: $max-width) {


### PR DESCRIPTION
The output was not what the current version outputs. The clearfix has changed in bourbon and the zoom:1 is no longer there