### PR TITLE
update deprecation warnings to mention current mixins

### DIFF
--- a/app/assets/stylesheets/grid/_row.scss
+++ b/app/assets/stylesheets/grid/_row.scss
@@ -30,13 +30,13 @@
 
 @mixin row($display: default, $direction: $default-layout-direction) {
   @if $direction != $default-layout-direction {
-    @include -neat-warn("The $direction argument will be deprecated in future versions in favor of the direction(){...} mixin.");
+    @include -neat-warn("The $direction argument will be deprecated in future versions in favor of the direction-context(){...} mixin.");
   }
 
   $layout-direction: $direction !global;
 
   @if $display != default {
-    @include -neat-warn("The $display argument will be deprecated in future versions in favor of the display(){...} mixin.");
+    @include -neat-warn("The $display argument will be deprecated in future versions in favor of the display-context(){...} mixin.");
   }
 
   @if $display == table {

--- a/app/assets/stylesheets/grid/_to-deprecate.scss
+++ b/app/assets/stylesheets/grid/_to-deprecate.scss
@@ -61,7 +61,7 @@
 
 @mixin reset-display {
   $container-display-table: false !global;
-  @include -neat-warn("Resetting $display will be deprecated in future versions in favor of the display(){...} mixin.");
+  @include -neat-warn("Resetting $display will be deprecated in future versions in favor of the display-context(){...} mixin.");
 }
 
 /// Resets the active layout direction to the default value set in `$default-layout-direction`. Particularly useful when changing the layout direction in a single row.
@@ -77,7 +77,7 @@
 
 @mixin reset-layout-direction {
   $layout-direction: $default-layout-direction !global;
-  @include -neat-warn("Resetting $direction will be deprecated in future versions in favor of the direction(){...} mixin.");
+  @include -neat-warn("Resetting $direction will be deprecated in future versions in favor of the direction-context(){...} mixin.");
 }
 
 /// Resets both the active layout direction and the active display property.


### PR DESCRIPTION
The `display()` and `direction()` mixins as mentioned in the deprecation warnings don't exist. Currently the mixins are named `display-context()` and `direction-context()`