### PR TITLE
Let `pad` mixin accept `null` to skip a side

### DIFF
--- a/app/assets/stylesheets/grid/_pad.scss
+++ b/app/assets/stylesheets/grid/_pad.scss
@@ -3,7 +3,7 @@
 /// Adds padding to the element.
 ///
 /// @param {List} $padding [flex-gutter()]
-///   A list of padding value(s) to use. Passing `default` in the list will result in using the gutter width as a padding value.
+///   A list of padding value(s) to use. Passing `default` in the list will result in using the gutter width as a padding value. Use a `null` value to “skip” a side.
 ///
 /// @example scss - Usage
 ///   .element {
@@ -16,10 +16,10 @@
 ///   }
 
 @mixin pad($padding: flex-gutter()) {
-  $padding-list: null;
+  $vals: ();
   @each $value in $padding {
     $value: if($value == 'default', flex-gutter(), $value);
-    $padding-list: join($padding-list, $value);
+    $vals: append($vals, $value);
   }
-  padding: $padding-list;
+  @include directional-property(padding, false, $vals);
 }

--- a/spec/neat/pad_spec.rb
+++ b/spec/neat/pad_spec.rb
@@ -25,7 +25,29 @@ describe "@include pad()" do
 
   context "with argument (default)" do
     it "uses default gutter percentage" do
-      expect(".pad-shorthand-default").to have_rule("padding: 30px 2.35765% 10px 2.35765%")
+      expect(".pad-shorthand-default").to have_rule("padding: 30px 2.35765% 10px")
+    end
+  end
+
+  context "with argument (null)" do
+    it "ignores rules with null values" do
+      ruleset = "padding-right: 10px; " +
+                "padding-left: 10px;"
+      bad_rule = "padding-top: null;"
+
+      expect(".pad-null-values").to have_ruleset(ruleset)
+      expect(".pad-null-values").to_not have_rule(bad_rule)
+    end
+  end
+
+  context "with argument (null default)" do
+    it "sets right and left paddings to gutter percentage" do
+      ruleset = "padding-right: 2.35765%; " +
+                "padding-left: 2.35765%;"
+      bad_rule = "padding-top: null;"
+
+      expect(".pad-null-and-default").to have_ruleset(ruleset)
+      expect(".pad-null-and-default").to_not have_rule(bad_rule)
     end
   end
 end

--- a/spec/support/matchers/have_ruleset.rb
+++ b/spec/support/matchers/have_ruleset.rb
@@ -1,0 +1,20 @@
+RSpec::Matchers.define :have_ruleset do |expected|
+  match do |selector|
+    @ruleset = rules_from_selector(selector)
+    @ruleset.join("; ") == expected
+  end
+
+  failure_message do |selector|
+    if @ruleset.empty?
+      %{no CSS for selector #{selector} were found}
+    else
+      ruleset = @ruleset.join("; ")
+      %{Expected selector #{selector} to have CSS rule "#{expected}".
+        Had "#{ruleset}".}
+    end
+  end
+
+  def rules_from_selector(selector)
+    ParserSupport.parser.find_by_selector(selector)
+  end
+end

--- a/test/pad.scss
+++ b/test/pad.scss
@@ -15,3 +15,11 @@
 .pad-shorthand-default {
   @include pad(30px default 10px default);
 }
+
+.pad-null-values {
+  @include pad(null 10px null 10px);
+}
+
+.pad-null-and-default {
+  @include pad(null default);
+}


### PR DESCRIPTION
Because this mixin was only outputting `padding` property, it was hard
to avoid overriding inherited padding values.
Now, we can skip any side by passing `null` in the list of values.
`pad` now requires Bourbon's `directional-property` mixin.

Fix #113