### PR TITLE
When test fails, output css that was found instead

### DIFF
--- a/spec/support/matchers/have_rule.rb
+++ b/spec/support/matchers/have_rule.rb
@@ -1,14 +1,16 @@
 RSpec::Matchers.define :have_rule do |expected|
-  match do |actual|
-    @rules = rules_from_selector(actual)
+  match do |selector|
+    @rules = rules_from_selector(selector)
     @rules.include? expected
   end
 
-  failure_message do |actual|
+  failure_message do |selector|
     if @rules.empty?
-      %{no CSS rules for selector #{actual} were found}
+      %{no CSS for selector #{selector} were found}
     else
-      %{expected selector #{actual} to have CSS rule "#{expected}"}
+      rules = @rules.join("; ")
+      %{Expected selector #{selector} to have CSS rule "#{expected}".
+        Had "#{rules}".}
     end
   end
 


### PR DESCRIPTION
This updates the `have_rule` RSpec matcher to output the found CSS rules in case of a failure.
It's easier to understand what's happening.
I basically stole [this commit](https://github.com/thoughtbot/bourbon/commit/788578850a5626a959f26044fd69f348ce159958) from Bourbon 