### PR TITLE
Improve README code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ First off, if you are planning to override the default grid settings (12 columns
 In your newly created  `_grid-settings.scss`, import `neat-helpers` if you are planning to use `new-breakpoint()`, then define your new variables:
 
 ```scss
+@import "bourbon/bourbon"; // or "bourbon" when in Rails
 @import "neat/neat-helpers"; // or "neat-helpers" when in Rails
 
 // Change the grid settings


### PR DESCRIPTION
Related to issue: https://github.com/thoughtbot/neat/issues/360

The example snippet will cause the error `undefined variable $golden` on the current Rails/Bourbon/Neat versions.

It looks like Bourbon just needs to be loaded first, so here is an update to the readem so others can avoid this confusion.