### PR TITLE
Add missing closing brace to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,4 +38,5 @@
     "gulp-connect": "^2.2.0",
     "gulp-sass": "^2.0.2",
     "node-bourbon": "^4.2.3"
+  }
 }


### PR DESCRIPTION
When trying to use the `bourbon-neat` NPM package I was getting an error that the `package.json` file was not valid JSON (because of the missing closing brace).