### PR TITLE
Make bourbon-neat a proper npm package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+module.exports = {
+  includePaths: [
+    path.join(__dirname, 'app/assets/stylesheets'),
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "name": "thoughtbot",
     "url": "http://thoughtbot.com"
   },
-  "main": "app/assets/stylesheets/_neat.scss",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/thoughtbot/neat.git"


### PR DESCRIPTION
When requiring `bourbon-neat` in Node it currently imports `neat.scss`.

This changes the entrypoint to `index.js` which exposes `includePaths`.
The `includePaths` can be passed to libsass which are used to resolve
`@import` declarations.