### PR TITLE
Do not reset margin on orphan nested elements in span-columns mixin

### DIFF
--- a/app/assets/stylesheets/grid/_span-columns.scss
+++ b/app/assets/stylesheets/grid/_span-columns.scss
@@ -46,7 +46,7 @@
 ///     width: 30.11389%;
 ///   }
 ///
-///   .element .nested-element:last-child {
+///   .element .nested-element:last-child:not(:first-child) {
 ///     margin-right: 0;
 ///   }
 
@@ -86,7 +86,7 @@
       margin-#{$direction}: flex-gutter($container-columns);
       width: flex-grid($columns, $container-columns);
 
-      &:last-child {
+      &:last-child:not(:first-child) {
         margin-#{$direction}: 0;
       }
     }

--- a/spec/neat/columns_spec.rb
+++ b/spec/neat/columns_spec.rb
@@ -23,7 +23,7 @@ describe "@include span-columns()" do
     end
 
     it "removes gutter from last element" do
-      expect(".span-columns-default:last-child").to have_rule("margin-right: 0")
+      expect(".span-columns-default:last-child:not(:first-child)").to have_rule("margin-right: 0")
     end
   end
 


### PR DESCRIPTION
Using span-columns in administrate gem as in this example:

``` css
.form-field {
  ...

  label {
    @include span-columns(2 of 12);
   ...
  }
 ...
}
```

https://github.com/thoughtbot/administrate/blob/4eede3b15df668/app/assets/stylesheets/administrate/components/_form.scss#L5-L16

works for default rendered html like:

``` html
<div class="form-field">
  <label>Test</label>
  <input name="test">
</div>
```

but layout brokes when form is returned with errors:

``` html
<div class="form-field">
  <div class="field_with_errors"><label>Test</label></div>
  <div class="field_with_errors"><input name="test"></div>
</div>
```

This change ensures that margin is present if nested element is last but
also first child.
