### PR TITLE
Update _row.scss

### DIFF
--- a/app/assets/stylesheets/grid/_row.scss
+++ b/app/assets/stylesheets/grid/_row.scss
@@ -43,10 +43,10 @@
     display: table;
     @include fill-parent;
     table-layout: fixed;
-    $container-display-table: true !global;
+    $container-display-table: true;
   } @else {
     @include clearfix;
     display: block;
-    $container-display-table: false !global;
+    $container-display-table: false;
   }
 }


### PR DESCRIPTION
Removes !global to prevent display: table-cell; from being applied to all elements following a @include row(table); setting.