### PR TITLE
Add missing bracket at the end of package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,4 +38,5 @@
     "gulp-connect": "^2.2.0",
     "gulp-sass": "^2.0.2",
     "node-bourbon": "^4.2.3"
+  }
 }


### PR DESCRIPTION
`npm install` was failling due to missing bracket 