### PR TITLE
Add grid-column

### DIFF
--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -1,0 +1,9 @@
+@charset "UTF-8";
+// Neat 2.0.0-alpha.0
+// http://neat.bourbon.io
+// Copyright 2012 thoughtbot, inc.
+// MIT License
+
+@import "neat/settings/settings";
+
+@import "neat/mixins/grid-column";

--- a/core/neat/mixins/_grid-column.scss
+++ b/core/neat/mixins/_grid-column.scss
@@ -1,0 +1,39 @@
+@charset "UTF-8";
+/// Creates Neat a grid column of requested size.
+///
+/// @argument {number (unitless)} $columns [1]
+///
+/// @argument {map} $grid [$neat-default-grid]
+///   The grid to be used to generate the column. By default, the global
+///   `$neat-default-grid` will be used.
+///
+/// @example scss
+///   .element {
+///     @include grid-column(3);
+///   }
+///
+/// @example css
+///   .element {
+///     width: calc(25% - 25px);
+///     float: left;
+///     margin-left: 20px;
+///   }
+
+@mixin grid-column($columns: 1, $grid: $neat-default-grid) {
+  $_grid-columns: map-get($grid, columns);
+  $_grid-gutter: map-get($grid, gutter);
+
+  $_column-ratio: $columns / $_grid-columns;
+
+  @if $_grid-gutter > 0 {
+    $_gutter-affordance: $_grid-gutter + ($_grid-gutter * $_column-ratio);
+    $_column-width-calc: unquote("#{percentage($_column-ratio)} - #{$_gutter-affordance}");
+
+    width: calc(#{$_column-width-calc});
+  } @else {
+    width: percentage($_column-ratio);
+  }
+
+  float: left;
+  margin-left: $_grid-gutter;
+}

--- a/core/neat/settings/_settings.scss
+++ b/core/neat/settings/_settings.scss
@@ -1,0 +1,17 @@
+@charset "UTF-8";
+/// Neat default grid.
+///
+/// @type map
+///
+/// @property {number (unitless)} columns 12
+///   Number of grid columns
+///
+/// @property {number (with unit)} gutter 40px
+///   Grid gutter width.
+///
+/// @access private
+
+$neat-default-grid: (
+  columns: 12,
+  gutter: 20px
+);


### PR DESCRIPTION
These changes introduce the use of `calc` within Neat, allowing for more flexible use of the system. This includes the use of static values (ie 1.25rem) or the grid's gutters, while having percentage values for a column's width, like 1/3 or 25%.