### PR TITLE
Reorganize npm dependencies

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,8 +1,8 @@
-var gulp = require("gulp"),
-  autoprefix = require("gulp-autoprefixer"),
-  sass = require("gulp-sass"),
-  connect = require("gulp-connect"),
-  bourbon = require("node-bourbon").includePaths;
+var bourbon    = require("bourbon").includePaths,
+    autoprefix = require("gulp-autoprefixer"),
+    connect    = require("gulp-connect"),
+    gulp       = require("gulp"),
+    sass       = require("gulp-sass");
 
 var paths = {
   scss: [

--- a/package.json
+++ b/package.json
@@ -34,11 +34,14 @@
     "test": "echo \"No test specified\""
   },
   "dependencies": {
-    "gulp": "^3.8.11",
-    "gulp-autoprefixer": "^2.3.1",
-    "gulp-connect": "^2.2.0",
-    "gulp-sass": "^2.0.2",
-    "node-bourbon": "^4.2.3"
+    "bourbon": "^4.2",
+    "node-sass": "^3.4"
+  },
+  "devDependencies": {
+    "gulp": "^3.9",
+    "gulp-autoprefixer": "^3.1",
+    "gulp-connect": "^2.3",
+    "gulp-sass": "^2.2"
   },
   "eyeglass": {
     "name": "neat",


### PR DESCRIPTION
Reorganize npm dependencies, as Neat doesn’t actually _depend_ on Gulp, these are only for development to run the contributing site.
- Break out development dependencies
- Update packages
- Swap `node-bourbon` for `bourbon`

Am I correctly including `node-sass` here? Neat does require Sass to run, so I think we should’ve been including a Sass compiler as a dependency?