### PR TITLE
Add sass requirement

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -1,3 +1,4 @@
+require "sass"
 require "bourbon"
 require "neat/generator"
 


### PR DESCRIPTION
Neat adds it's stylesheets to the Sass load paths however we are not
requiring sass explicitly. Previously, Sass was being required
implicitly through bourbon however, as of bourbon-5.0 Sass is no longer
required in the gem itself resulting in an error within Neat.

Resolves https://github.com/thoughtbot/neat/issues/429