### PR TITLE
Update naming of `grid-calc()` to `_neat-column-width()`

### DIFF
--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -7,7 +7,7 @@
 @import "neat/settings/settings";
 
 @import "neat/functions/retrieve-neat-settings";
-@import "neat/functions/grid-calc";
+@import "neat/functions/neat-column-width";
 
 @import "neat/mixins/grid-column";
 @import "neat/mixins/grid-container";

--- a/core/neat/functions/_neat-column-width.scss
+++ b/core/neat/functions/_neat-column-width.scss
@@ -8,11 +8,11 @@
 /// @return {string}
 ///
 /// @example scss
-///   _grid-calc($neat-grid, 4)
+///   _neat-column-width($neat-grid, 4)
 ///
 /// @access private
 
-@function grid-calc($grid, $columns) {
+@function _neat-column-width($grid, $columns) {
   $_column-ratio: $columns / _retrieve-neat-setting($grid, columns);
   $_gutter: _retrieve-neat-setting($grid, gutter);
   $_gutter-affordance: $_gutter + ($_gutter * $_column-ratio);

--- a/core/neat/mixins/_grid-column.scss
+++ b/core/neat/mixins/_grid-column.scss
@@ -26,7 +26,7 @@
 
   @if $_grid-gutter > 0 {
 
-    width: calc(#{grid-calc($grid, $columns)});
+    width: calc(#{_neat-column-width($grid, $columns)});
   } @else {
     width: percentage($_column-ratio);
   }

--- a/core/neat/mixins/_grid-push.scss
+++ b/core/neat/mixins/_grid-push.scss
@@ -23,7 +23,7 @@
 
   @if $push {
     $_gutter-affordance: $_grid-gutter * 2;
-    $_margin-value: calc(#{unquote(grid-calc($grid, $push))} + #{$_gutter-affordance});
+    $_margin-value: calc(#{_neat-column-width($grid, $push)} + #{$_gutter-affordance});
     margin-left: $_margin-value;
   } @else {
     $_margin-value: _retrieve-neat-setting($grid, gutter);


### PR DESCRIPTION
Naming a function "-grid-calc" is disallowed and will be an error in future
versions of Sass. This name conflicts with an existing CSS function with
special parse rules.