### PR TITLE
Added a shorthand for custom grids like `2 of 5`

### DIFF
--- a/contrib/index.html
+++ b/contrib/index.html
@@ -35,6 +35,9 @@
         <div class="grid__column box"></div>
         <div class="grid__column box"></div>
         <div class="grid__column box"></div>
+        <div class="grid__column--full">
+          <h3>Nested Grid</h3>
+        </div>
         <div class="grid__column--thirds grid--nested">
           <div class="grid--nested__column box--alt"></div>
           <div class="grid--nested__column box--alt"></div>
@@ -42,7 +45,16 @@
         </div>
         <div class="grid__column--thirds box"></div>
         <div class="grid__column--thirds box"></div>
+        <div class="grid__column--full">
+          <h3>Push Grid</h3>
+        </div>
         <div class="grid__column--thirds box grid-push--3"></div>
+        <div class="grid__column--full">
+          <h3>Shorthand Sub-Grid</h3>
+        </div>
+        <div class="grid__column--3-of-5 box"></div>
+        <div class="grid__column--2-of-5 box"></div>
+        <div class="grid__column--3-of-5 box grid-push--2-of-5"></div>
       </div>
     </main>
   </body>

--- a/contrib/patterns/_grid-push.scss
+++ b/contrib/patterns/_grid-push.scss
@@ -1,3 +1,7 @@
 .grid-push--3 {
   @include grid-push(3);
 }
+
+.grid-push--2-of-5 {
+  @include grid-push(2 of 5);
+}

--- a/contrib/patterns/_grid.scss
+++ b/contrib/patterns/_grid.scss
@@ -13,3 +13,11 @@
 .grid__column--full {
   @include grid-column(12);
 }
+
+.grid__column--3-of-5 {
+  @include grid-column(3 of 5);
+}
+
+.grid__column--2-of-5 {
+  @include grid-column(2 of 5);
+}

--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -8,6 +8,8 @@
 
 @import "neat/functions/retrieve-neat-settings";
 @import "neat/functions/neat-column-width";
+@import "neat/functions/neat-column-ratio";
+@import "neat/functions/neat-parse-columns";
 
 @import "neat/mixins/grid-column";
 @import "neat/mixins/grid-container";

--- a/core/neat/functions/_neat-column-ratio.scss
+++ b/core/neat/functions/_neat-column-ratio.scss
@@ -1,0 +1,24 @@
+@charset "UTF-8";
+/// Determine the ratio of `$columns` to the total column count.
+/// If `$columns` is more than one value, they are handed to
+/// `_neat-parse-columns()` which will detirmine the total columns and use this
+/// value instead of `total-columns`.
+///
+/// @argument {map} $grid
+///
+/// @argument {number | list} $columns
+///
+/// @return {number}
+///
+/// @example scss
+///   _neat-column-ratio($grid, 3)
+///
+/// @access private
+
+@function _neat-column-ratio($grid, $columns) {
+  @if length($columns) > 1 {
+    @return nth($columns, 1) / _neat-parse-columns($columns);
+  } @else if $columns {
+    @return $columns / _retrieve-neat-setting($grid, columns);
+  }
+}

--- a/core/neat/functions/_neat-column-width.scss
+++ b/core/neat/functions/_neat-column-width.scss
@@ -13,7 +13,7 @@
 /// @access private
 
 @function _neat-column-width($grid, $columns) {
-  $_column-ratio: $columns / _retrieve-neat-setting($grid, columns);
+  $_column-ratio: _neat-column-ratio($grid, $columns);
   $_gutter: _retrieve-neat-setting($grid, gutter);
   $_gutter-affordance: $_gutter + ($_gutter * $_column-ratio);
 

--- a/core/neat/functions/_neat-parse-columns.scss
+++ b/core/neat/functions/_neat-parse-columns.scss
@@ -1,0 +1,22 @@
+@charset "UTF-8";
+/// Parse a column count like `3 of 5` and retur the total coloumn count.
+/// This is to allow a shorthand for custom grids without using a settings map.
+///
+///
+/// @argument {list} $span
+///
+/// @return {number}
+///
+/// @example scss
+///   _neat-parse-columns(3 of 5)
+///
+/// @access private
+
+@function _neat-parse-columns($span) {
+  @if length($span) == 3 {
+    $_total-columns: nth($span, 3);
+    @return $_total-columns;
+  } @else if length($span) == 2 or if length($span) >= 3 {
+    @error "`$column` should contain 2 values, seperated by an `of`";
+  }
+}


### PR DESCRIPTION
This feature is a carryover from Neat 1.x. While it should be considered an
advanced feature, It can be useful on a component level. The "official" way to
do this is to create a map for your sub-grid and pass it in to the mixin.

To achieve this, `neat-column-ratio` determines the ratio of the `$column`
to the total columns as defined in `$neat-grid` if it detects multiple values (a
list), it will pass the value to the `neat-parse-column`. This function will
return the third value assuming this is meant to be the total column value.