### PR TITLE
Add grid-media mixin to allow the creation of media queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org).
 - Added `grid-container` for floated grid which contains a simple clearfix
 - Added `grid-push` functionality
 - Added `grid-shift` functionality
+- Added `grid-media` to allow the creation of media queries with custom grids
 
 ### Changed
 

--- a/contrib/base/_variables.scss
+++ b/contrib/base/_variables.scss
@@ -1,3 +1,8 @@
 $color-neat-blue: #53aee0;
 $color-neat-orange: #ff7c56;
 $color-white: #fff;
+
+$neat-grid: (
+  columns: 12,
+  gutter: 20px,
+);

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -60,6 +60,10 @@
         <div class="grid__column--3-of-5 box"></div>
         <div class="grid__column--2-of-5 box"></div>
         <div class="grid__column--3-of-5 box grid-push--2-of-5"></div>
+        <div class="grid__column--full">
+          <h3>Grid Media Queries</h3>
+        </div>
+        <div class="grid-column--media-3-to-6 box"></div>
       </div>
     </main>
   </body>

--- a/contrib/patterns/_grid-media.scss
+++ b/contrib/patterns/_grid-media.scss
@@ -1,5 +1,4 @@
 $medium-screen: 1000px;
-$medium: "only screen and (min-width:#{$medium-screen})";
 
 $custom-neat-grid: (
   columns: 12,
@@ -9,7 +8,7 @@ $custom-neat-grid: (
 .grid-column--media-3-to-6 {
   @include grid-column(3);
 
-  @include grid-media($medium, $custom-neat-grid) {
+  @include grid-media($medium-screen, $custom-neat-grid) {
     @include grid-column(6);
   }
 }

--- a/contrib/patterns/_grid-media.scss
+++ b/contrib/patterns/_grid-media.scss
@@ -1,0 +1,15 @@
+$medium-screen: 1000px;
+$medium: "only screen and (min-width:#{$medium-screen})";
+
+$custom-neat-grid: (
+  columns: 12,
+  gutter: 50px,
+);
+
+.grid-column--media-3-to-6 {
+  @include grid-column(3);
+
+  @include grid-media($medium, $custom-neat-grid) {
+    @include grid-column(6);
+  }
+}

--- a/contrib/patterns/_grid-media.scss
+++ b/contrib/patterns/_grid-media.scss
@@ -3,12 +3,50 @@ $medium-screen: 1000px;
 $custom-neat-grid: (
   columns: 12,
   gutter: 50px,
+  media: $medium-screen,
+);
+
+$specific-neat-grid: (
+  columns: 12,
+  gutter: 80px,
+  media: "only screen and (min-width: 1000px) and (max-width: 1100px)",
+);
+
+
+$print-neat-grid: (
+  columns: 10,
+  gutter: 20px,
+  media: print,
 );
 
 .grid-column--media-3-to-6 {
   @include grid-column(3);
 
-  @include grid-media($medium-screen, $custom-neat-grid) {
+  &::before {
+    content: "#{map-get($neat-grid, media)}";
+  }
+
+  @include grid-media($custom-neat-grid) {
     @include grid-column(6);
+
+    &::before {
+      content: "#{map-get($neat-grid, media)}";
+    }
+  }
+
+  @include grid-media($specific-neat-grid) {
+    @include grid-column(6);
+
+    &::before {
+      content: "#{map-get($neat-grid, media)}";
+    }
+  }
+
+  @include grid-media($print-neat-grid) {
+    @include grid-column(6);
+
+    &::before {
+      content: "#{map-get($neat-grid, media)}";
+    }
   }
 }

--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -9,3 +9,4 @@
 @import "patterns/grid-nested";
 @import "patterns/grid-push";
 @import "patterns/grid-shift";
+@import "patterns/grid-media";

--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -11,6 +11,7 @@
 @import "neat/functions/neat-column-width";
 @import "neat/functions/neat-column-ratio";
 @import "neat/functions/neat-parse-columns";
+@import "neat/functions/neat-parse-media";
 
 @import "neat/mixins/grid-column";
 @import "neat/mixins/grid-container";

--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -14,5 +14,6 @@
 
 @import "neat/mixins/grid-column";
 @import "neat/mixins/grid-container";
+@import "neat/mixins/grid-media";
 @import "neat/mixins/grid-push";
 @import "neat/mixins/grid-shift";

--- a/core/neat/functions/_neat-parse-media.scss
+++ b/core/neat/functions/_neat-parse-media.scss
@@ -1,21 +1,19 @@
 @charset "UTF-8";
 /// Parse media types. If the property is a string then return it, otherwise
-/// inherit the grid defaults.
+/// assume screen and min-width.
 ///
 /// @argument {string | number (with unit)} $media
 ///
 /// @return {number}
 ///
 /// @example scss
-///   _neat-parse-media(1000px)
+///   _neat-parse-media($grid, 1000px)
 ///
 /// @access private
 
-@function _neat-parse-media($grid, $media) {
+@function _neat-parse-media($media) {
   @if type-of($media) == number {
-    $_grid-media: _retrieve-neat-setting($grid, media);
-    @return "only screen and (#{$_grid-media}: #{$media})";
-
+    @return "only screen and (min-width: #{$media})";
   } @else if type-of($media) == string {
     @return "#{$media}";
   }

--- a/core/neat/functions/_neat-parse-media.scss
+++ b/core/neat/functions/_neat-parse-media.scss
@@ -1,0 +1,22 @@
+@charset "UTF-8";
+/// Parse media types. If the property is a string then return it, otherwise
+/// inherit the grid defaults.
+///
+/// @argument {string | number (with unit)} $media
+///
+/// @return {number}
+///
+/// @example scss
+///   _neat-parse-media(1000px)
+///
+/// @access private
+
+@function _neat-parse-media($grid, $media) {
+  @if type-of($media) == number {
+    $_grid-media: _retrieve-neat-setting($grid, media);
+    @return "only screen and (#{$_grid-media}: #{$media})";
+
+  } @else if type-of($media) == string {
+    @return "#{$media}";
+  }
+}

--- a/core/neat/mixins/_grid-media.scss
+++ b/core/neat/mixins/_grid-media.scss
@@ -1,0 +1,42 @@
+@charset "UTF-8";
+/// Creates a media query that styles can be passed in to. This mixin also
+/// allows users to define a custom grid that is used exclusively within the
+/// confines of the mixin.
+///
+/// @argument {string} $query
+///
+/// @argument {map} $grid [$neat-grid]
+///   The grid used to generate the column.
+///
+/// @example scss
+///   .element {
+///     @include grid-column(3);
+///
+///     @include grid-media($medium, $custom-neat-grid){
+///       @include grid-column(6);
+///     }
+///   }
+///
+/// @example css
+///   .element {
+///     width: calc(25% - 25px);
+///     float: left;
+///     margin-left: 20px;
+///   }
+///
+///   @media only screen and (min-width: 1000px) {
+///     .element {
+///       width: calc(50% - 75px);
+///       float: left;
+///       margin-left: 50px;
+///     }
+///   }
+
+@mixin grid-media($query, $grid: $neat-grid) {
+  @media #{$query} {
+    $_default-neat-grid: $neat-grid;
+    $neat-grid: $grid !global;
+    @content;
+    $neat-grid: $_default-neat-grid !global;
+  }
+}

--- a/core/neat/mixins/_grid-media.scss
+++ b/core/neat/mixins/_grid-media.scss
@@ -1,18 +1,23 @@
 @charset "UTF-8";
-/// Creates a media query that styles can be passed in to. This mixin also
-/// allows users to define a custom grid that is used exclusively within the
-/// confines of the mixin.
+/// Creates a media query in which custom grid properties can be defined.
+/// Add the `media` property to your custom grid settings map and add the media
+/// you would like to scope to. If  only a number is defined, it is assumed this
+/// is a `min-with` value. Your custom grid can then be passed to the mixin.
 ///
-/// @argument {string} $query
-///
-/// @argument {map} $grid [$neat-grid]
+/// @argument {map} $grid
 ///   The grid used to generate the column.
 ///
 /// @example scss
+///   $custom-neat-grid: (
+///     columns: 12,
+///     gutter: 50px,
+///     media: 1000px,
+///   );
+///
 ///   .element {
 ///     @include grid-column(3);
 ///
-///     @include grid-media($medium, $custom-neat-grid){
+///     @include grid-media($custom-neat-grid){
 ///       @include grid-column(6);
 ///     }
 ///   }
@@ -32,8 +37,9 @@
 ///     }
 ///   }
 
-@mixin grid-media($query, $grid: $neat-grid) {
-  $_query: _neat-parse-media($grid, $query);
+@mixin grid-media($grid) {
+  $_media: _retrieve-neat-setting($grid, media);
+  $_query: _neat-parse-media($grid, $_media);
 
   @media #{$_query} {
     $_default-neat-grid: $neat-grid;

--- a/core/neat/mixins/_grid-media.scss
+++ b/core/neat/mixins/_grid-media.scss
@@ -33,7 +33,9 @@
 ///   }
 
 @mixin grid-media($query, $grid: $neat-grid) {
-  @media #{$query} {
+  $_query: _neat-parse-media($grid, $query);
+
+  @media #{$_query} {
     $_default-neat-grid: $neat-grid;
     $neat-grid: $grid !global;
     @content;

--- a/core/neat/settings/_settings.scss
+++ b/core/neat/settings/_settings.scss
@@ -9,11 +9,15 @@
 /// @property {number (with unit)} gutter [20px]
 ///   Default grid gutter width.
 ///
+/// @property {string} gutter [min-width]
+///   Grid media query type including min-width and max-width
+///
 /// @access private
 
 $_neat-grid-defaults: (
   columns: 12,
   gutter: 20px,
+  media: min-width,
 );
 
 /// This variable is a sass map that overrides Neat's default grid settings.

--- a/core/neat/settings/_settings.scss
+++ b/core/neat/settings/_settings.scss
@@ -9,15 +9,15 @@
 /// @property {number (with unit)} gutter [20px]
 ///   Default grid gutter width.
 ///
-/// @property {string} gutter [min-width]
-///   Grid media query type including min-width and max-width
+/// @property {string | number (with unit)} gutter [null]
+///   Grid media query.
 ///
 /// @access private
 
 $_neat-grid-defaults: (
   columns: 12,
   gutter: 20px,
-  media: min-width,
+  media: null,
 );
 
 /// This variable is a sass map that overrides Neat's default grid settings.

--- a/spec/fixtures/functions/neat-parse-media.scss
+++ b/spec/fixtures/functions/neat-parse-media.scss
@@ -1,0 +1,9 @@
+@import "setup";
+
+.neat-parse-media-number {
+  content: _neat-parse-media(100px);
+}
+
+.neat-parse-media-string {
+  content: _neat-parse-media("only screen and (max-width: 25rem)");
+}

--- a/spec/neat/functions/neat_parse_media_spec.rb
+++ b/spec/neat/functions/neat_parse_media_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "neat-parse-media" do
+  before(:all) do
+    ParserSupport.parse_file("functions/neat-parse-media")
+  end
+
+  context "called with number" do
+    it "gets min-width wraped number" do
+      rule = 'content: "only screen and (min-width: 100px)"'
+
+      expect(".neat-parse-media-number").to have_rule(rule)
+    end
+  end
+
+  context "called with string" do
+    it "gets the string" do
+      rule = 'content: "only screen and (max-width: 25rem)"'
+
+      expect(".neat-parse-media-string").to have_rule(rule)
+    end
+  end
+end


### PR DESCRIPTION
So this kind of blew my mind that it works as well as it does. The `grid-media` mixin allows a user to put create a mediaquery and pass in a string with the scope of the mq.

As with ~~most~~ all of the mixins in the library, this mixin also acceps a grid map as it's second value. this means that you can either pass a new grid in directly, or more likely, you can define multiple grids within your variables file and then pass them directly in to the mixin's second peramiter. The condrib scss shows this nicely:

```scss
$medium-screen: 1000px;
$medium: "only screen and (min-width:#{$medium-screen})";

$neat-grid: (
  columns: 12,
  gutter: 20px
);


$custom-neat-grid: (
  columns: 12,
  gutter: 50px,
);

.grid-column--media-3-to-6 {
  @include grid-column(3);

  @include grid-media($medium, $custom-neat-grid){
    @include grid-column(6);
  }
}
```

The `grid-column` outside of the mq will inherit the `$neat-grid`, however the `grid-column` inside the mq will have the properties of `$custom-neat-grid`. This is shown in the gif below.

![moo](https://cloud.githubusercontent.com/assets/2489247/16898946/9b4b334e-4bbe-11e6-8c12-80883de9f454.gif)

Ass the screen size increases, you are able to see the columns gutter change from 20px, to 50. So fuckin cool.