### PR TITLE
Update `neat-settings` documentation

### DIFF
--- a/core/neat/settings/_settings.scss
+++ b/core/neat/settings/_settings.scss
@@ -4,19 +4,21 @@
 /// @type map
 ///
 /// @property {number (unitless)} columns [12]
-///   Number of grid columns.
+///   Deefault number of grid columns.
 ///
 /// @property {number (with unit)} gutter [20px]
-///   Grid gutter width.
+///   Default grid gutter width.
 ///
 /// @access private
 
 $_neat-grid-defaults: (
   columns: 12,
-  gutter: 20px
+  gutter: 20px,
 );
 
-/// User overrides of Bourbon configuration settings.
+/// This variable is a sass map that overrides Neat's default grid settings.
+/// Use this to define your project's grid properties incluting gutters, and
+/// total column count.
 ///
 /// @type map
 ///
@@ -25,5 +27,11 @@ $_neat-grid-defaults: (
 ///
 /// @property {number (with unit)} gutter [20px]
 ///   Grid gutter width.
+///
+/// @example scss
+///   $neat-grid: (
+///     columns: 12,
+///     gutter: 20px,
+///   );
 
 $neat-grid: () !default;


### PR DESCRIPTION
The documentation for `$neat-settings` was basically non existent which meant the new docs site looked like…

<img width="580" alt="screen shot 2016-07-17 at 11 36 27 am" src="https://cloud.githubusercontent.com/assets/2489247/16901889/fc844146-4c1d-11e6-89b2-1e30c32443cd.png">

Not super informative.
