### PR TITLE
Add `grid-shift` mixin allowing for the reordering of columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org).
 - Added improved documentation and releasing information
 - Added `grid-container` for floated grid which contains a simple clearfix
 - Added `grid-push` functionality
+- Added `grid-shift` functionality
 
 ### Changed
 

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -50,6 +50,11 @@
         </div>
         <div class="grid__column--thirds box grid-push--3"></div>
         <div class="grid__column--full">
+          <h3>Shift Grid</h3>
+        </div>
+        <div class="grid__column--8 grid-shift--4 box">&nbsp;First</div>
+        <div class="grid__column--4 grid-shift--neg-8 box">&nbsp;Second</div>
+        <div class="grid__column--full">
           <h3>Shorthand Sub-Grid</h3>
         </div>
         <div class="grid__column--3-of-5 box"></div>

--- a/contrib/patterns/_box.scss
+++ b/contrib/patterns/_box.scss
@@ -1,7 +1,8 @@
 .box {
   background-color: $color-neat-blue;
-  height: 30px;
   margin-bottom: 10px;
+  min-height: 30px;
+  padding: 0.5rem;
 }
 
 .box--alt {

--- a/contrib/patterns/_grid-shift.scss
+++ b/contrib/patterns/_grid-shift.scss
@@ -1,0 +1,7 @@
+.grid-shift--4 {
+  @include grid-shift(4);
+}
+
+.grid-shift--neg-8 {
+  @include grid-shift(-8);
+}

--- a/contrib/patterns/_grid.scss
+++ b/contrib/patterns/_grid.scss
@@ -10,6 +10,14 @@
   @include grid-column(4);
 }
 
+.grid__column--4 {
+  @include grid-column(4);
+}
+
+.grid__column--8 {
+  @include grid-column(8);
+}
+
 .grid__column--full {
   @include grid-column(12);
 }

--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -8,3 +8,4 @@
 @import "patterns/grid";
 @import "patterns/grid-nested";
 @import "patterns/grid-push";
+@import "patterns/grid-shift";

--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -15,3 +15,4 @@
 @import "neat/mixins/grid-column";
 @import "neat/mixins/grid-container";
 @import "neat/mixins/grid-push";
+@import "neat/mixins/grid-shift";

--- a/core/neat/mixins/_grid-shift.scss
+++ b/core/neat/mixins/_grid-shift.scss
@@ -1,0 +1,31 @@
+@charset "UTF-8";
+/// Shift columns and reorder them within their container using relative
+/// positioning.
+///
+/// @argument {number (unitless)} $shift [false]
+///
+/// @argument {map} $grid [$neat-grid]
+///   The grid to be used to generate the column.
+///   By default, the global `$neat-grid` will be used.
+///
+/// @example scss
+///   .element {
+///     @include grid-shift(3);
+///   }
+///
+/// @example css
+///   .element {
+///     left: calc(25% - 25px + 20px);
+///     position: relative;
+///   }
+
+@mixin grid-shift($shift: false, $grid: $neat-grid) {
+  @if $shift {
+    $_shift-value: calc(#{_neat-column-width($grid, $shift)} + #{_retrieve-neat-setting($grid, gutter)});
+    left: $_shift-value;
+  } @else {
+    left: auto;
+  }
+
+  position: relative;
+}

--- a/spec/fixtures/mixins/grid-shift.scss
+++ b/spec/fixtures/mixins/grid-shift.scss
@@ -1,0 +1,38 @@
+@import "setup";
+
+$six-grid: (
+  columns: 6,
+  gutter: 2rem,
+);
+
+.grid-shift-default {
+  @include grid-shift;
+}
+
+.grid-shift-1-default {
+  @include grid-shift(1);
+}
+
+.grid-shift-6-default {
+  @include grid-shift(6);
+}
+
+.grid-shift-neg-6-default {
+  @include grid-shift(-6);
+}
+
+.grid-shift-0-six {
+  @include grid-shift(false, $six-grid);
+}
+
+.grid-shift-1-six {
+  @include grid-shift(1, $six-grid);
+}
+
+.grid-shift-3-six {
+  @include grid-shift(3, $six-grid);
+}
+
+.grid-shift-neg-3-six {
+  @include grid-shift(-3, $six-grid);
+}

--- a/spec/neat/mixins/grid_shift_spec.rb
+++ b/spec/neat/mixins/grid_shift_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+describe "grid-shift" do
+  before(:all) do
+    ParserSupport.parse_file("mixins/grid-shift")
+  end
+
+  context "called with default settings" do
+    it "adds relative positioning without moving the object" do
+      rule = "left: auto; position: relative;"
+
+      expect(".grid-shift-default").to have_ruleset(rule)
+    end
+
+    it "moves the object one column to the right" do
+      rule = "left: calc(8.33333% - 21.66667px + 20px); position: relative;"
+
+      expect(".grid-shift-1-default").to have_ruleset(rule)
+    end
+
+    it "moves the object six columns to the right" do
+      rule = "left: calc(50% - 30px + 20px); position: relative;"
+
+      expect(".grid-shift-6-default").to have_ruleset(rule)
+    end
+
+    it "moves the object six columns to the left" do
+      rule = "left: calc(-50% - 10px + 20px); position: relative;"
+
+      expect(".grid-shift-neg-6-default").to have_ruleset(rule)
+    end
+  end
+
+  context "called with custom settings" do
+    it "adds relative positioning without moving the object" do
+      rule = "left: auto; position: relative;"
+
+      expect(".grid-shift-0-six").to have_ruleset(rule)
+    end
+
+    it "moves the object one column to the right" do
+      rule = "left: calc(16.66667% - 2.33333rem + 2rem); position: relative;"
+
+      expect(".grid-shift-1-six").to have_ruleset(rule)
+    end
+
+    it "moves the object three columns to the right" do
+      rule = "left: calc(50% - 3rem + 2rem); position: relative;"
+
+      expect(".grid-shift-3-six").to have_ruleset(rule)
+    end
+
+    it "moves the object three columns to the left" do
+      rule = "left: calc(-50% - 1rem + 2rem); position: relative;"
+
+      expect(".grid-shift-neg-3-six").to have_ruleset(rule)
+    end
+  end
+end


### PR DESCRIPTION
Using relative positioning of columns, `grid-shift` allows the user to move a grid column a specified number of columns to the right or left. This is distinct from the `grid-push` mixin in that push is better suited for positioning an object on the page while shift is better at reordering 2 or more grid objects. It should be said that shift also adds the relative positioning attribute. 

The following is an example image of the following markup:

```html
<div class="grid__column--8 grid-shift--4 box">First</div>
<div class="grid__column--4 grid-shift--neg-8 box">Second</div>
```

![screen shot 2016-07-17 at 2 05 47 pm](https://cloud.githubusercontent.com/assets/2489247/16902290/08836a2a-4c29-11e6-8efc-e9449c79ea2f.png)
