### PR TITLE
Refactor `neat-column-width` to check if gutter is zero

### DIFF
--- a/contrib/patterns/_grid.scss
+++ b/contrib/patterns/_grid.scss
@@ -3,7 +3,7 @@
 }
 
 .grid__column {
-  @include grid-column;
+  @include grid-column(1);
 }
 
 .grid__column--thirds {

--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -7,6 +7,7 @@
 @import "neat/settings/settings";
 
 @import "neat/functions/retrieve-neat-settings";
+@import "neat/functions/neat-column-default";
 @import "neat/functions/neat-column-width";
 @import "neat/functions/neat-column-ratio";
 @import "neat/functions/neat-parse-columns";

--- a/core/neat/functions/_neat-column-default.scss
+++ b/core/neat/functions/_neat-column-default.scss
@@ -1,0 +1,23 @@
+@charset "UTF-8";
+/// Determine if a column count has been given.
+/// If no columns have been given return the grid's total column count.
+///
+/// @argument {map} $grid
+///
+/// @argument {number (unitless) | null} $columns
+///
+/// @return {number}
+///
+/// @example scss
+///   _neat-column-default($neat-grid, 4)
+///
+/// @access private
+
+@function _neat-column-default($grid, $columns) {
+  @if $columns == null {
+    $_grid-columns: _retrieve-neat-setting($grid, columns);
+    @return $_grid-columns;
+  } @else {
+    @return $columns;
+  }
+}

--- a/core/neat/functions/_neat-column-width.scss
+++ b/core/neat/functions/_neat-column-width.scss
@@ -15,7 +15,11 @@
 @function _neat-column-width($grid, $columns) {
   $_column-ratio: _neat-column-ratio($grid, $columns);
   $_gutter: _retrieve-neat-setting($grid, gutter);
-  $_gutter-affordance: $_gutter + ($_gutter * $_column-ratio);
 
-  @return unquote("#{percentage($_column-ratio)} - #{$_gutter-affordance}");
+  @if $_gutter == 0 {
+    @return unquote("#{percentage($_column-ratio)}");
+  } @else {
+    $_gutter-affordance: $_gutter + ($_gutter * $_column-ratio);
+    @return unquote("#{percentage($_column-ratio)} - #{$_gutter-affordance}");
+  }
 }

--- a/core/neat/mixins/_grid-column.scss
+++ b/core/neat/mixins/_grid-column.scss
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /// Creates Neat a grid column of requested size.
 ///
-/// @argument {number (unitless)} $columns [1]
+/// @argument {number (unitless)} $columns [null]
 ///
 /// @argument {map} $grid [$neat-grid]
 ///   The grid used to generate the column.
@@ -18,7 +18,8 @@
 ///     margin-left: 20px;
 ///   }
 
-@mixin grid-column($columns: 1, $grid: $neat-grid) {
+@mixin grid-column($columns: null, $grid: $neat-grid) {
+  $columns: _neat-column-default($grid, $columns);
   $_grid-columns: _retrieve-neat-setting($grid, columns);
   $_grid-gutter: _retrieve-neat-setting($grid, gutter);
 

--- a/core/neat/mixins/_grid-column.scss
+++ b/core/neat/mixins/_grid-column.scss
@@ -22,15 +22,7 @@
   $_grid-columns: _retrieve-neat-setting($grid, columns);
   $_grid-gutter: _retrieve-neat-setting($grid, gutter);
 
-  $_column-ratio: $columns / $_grid-columns;
-
-  @if $_grid-gutter > 0 {
-
-    width: calc(#{_neat-column-width($grid, $columns)});
-  } @else {
-    width: percentage($_column-ratio);
-  }
-
+  width: calc(#{_neat-column-width($grid, $columns)});
   float: left;
   margin-left: $_grid-gutter;
 }

--- a/spec/fixtures/functions/neat-column-default.scss
+++ b/spec/fixtures/functions/neat-column-default.scss
@@ -1,0 +1,22 @@
+@import "setup";
+
+$eighteen-grid: (
+  columns: 18,
+  gutter: 33px,
+);
+
+.neat-column-default-grid {
+  content: _neat-column-default($neat-grid, null);
+}
+
+.neat-column-default-grid-custom-col {
+  content: _neat-column-default($neat-grid, 10);
+}
+
+.neat-column-custom-grid {
+  content: _neat-column-default($eighteen-grid, null);
+}
+
+.neat-column-custom-grid-custom-col {
+  content: _neat-column-default($eighteen-grid, 10);
+}

--- a/spec/neat/functions/neat_column_default_spec.rb
+++ b/spec/neat/functions/neat_column_default_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+describe "neat-column-default" do
+  before(:all) do
+    ParserSupport.parse_file("functions/neat-column-default")
+  end
+
+  context "called with default grid" do
+    it "gets default columns" do
+      rule = "content: 12"
+
+      expect(".neat-column-default-grid").to have_rule(rule)
+    end
+
+    it "gets custom columns" do
+      rule = "content: 10"
+
+      expect(".neat-column-default-grid-custom-col").to have_rule(rule)
+    end
+  end
+
+  context "called with custom grid" do
+    it "gets default columns" do
+      rule = "content: 18"
+
+      expect(".neat-column-custom-grid").to have_rule(rule)
+    end
+
+    it "gets custom columns" do
+      rule = "content: 10"
+
+      expect(".neat-column-custom-grid-custom-col").to have_rule(rule)
+    end
+  end
+end


### PR DESCRIPTION
While `span-columns` contained a check for when the gutter equals zero.
Since calc operations fail when you attempt to add or subtract zero, an
operation like `calc(100% - 0)` would need to be output as `calc(100%)`.
This operation has been moved to the `neat-column-width` function so it
can be used by the other mixins.
