### PR TITLE
Add test coverage for negative values and shorthand

### DIFF
--- a/spec/fixtures/mixins/grid-column.scss
+++ b/spec/fixtures/mixins/grid-column.scss
@@ -2,12 +2,12 @@
 
 $six-grid: (
   columns: 6,
-  gutter: 1em
+  gutter: 1em,
 );
 
 $seventeen-grid: (
   columns: 17,
-  gutter: 10px
+  gutter: 10px,
 );
 
 .grid-column-1-of-default {
@@ -22,6 +22,10 @@ $seventeen-grid: (
   @include grid-column(12);
 }
 
+.grid-column-3-of-5-shorthand {
+  @include grid-column(3 of 5);
+}
+
 .grid-column-1-of-6 {
   @include grid-column(1, $six-grid);
 }
@@ -32,6 +36,10 @@ $seventeen-grid: (
 
 .grid-column-6-of-6 {
   @include grid-column(6, $six-grid);
+}
+
+.grid-column-3-of-5-shorthand-six-grid {
+  @include grid-column(3 of 5, $six-grid);
 }
 
 .grid-column-5-of-17 {
@@ -45,3 +53,5 @@ $seventeen-grid: (
 .grid-column-13-of-17 {
   @include grid-column(12, $seventeen-grid);
 }
+
+

--- a/spec/fixtures/mixins/grid-push.scss
+++ b/spec/fixtures/mixins/grid-push.scss
@@ -2,7 +2,7 @@
 
 $six-grid: (
   columns: 6,
-  gutter: 2rem
+  gutter: 2rem,
 );
 
 .grid-push-default {
@@ -17,6 +17,10 @@ $six-grid: (
   @include grid-push(6);
 }
 
+.grid-push-neg-6-default {
+  @include grid-push(-6);
+}
+
 .grid-push-0-six {
   @include grid-push(false, $six-grid);
 }
@@ -27,4 +31,8 @@ $six-grid: (
 
 .grid-push-3-six {
   @include grid-push(3, $six-grid);
+}
+
+.grid-push-neg-3-six {
+  @include grid-push(-3, $six-grid);
 }

--- a/spec/neat/mixins/grid_column_spec.rb
+++ b/spec/neat/mixins/grid_column_spec.rb
@@ -29,6 +29,14 @@ describe "grid-column" do
 
       expect(".grid-column-12-of-default").to have_ruleset(ruleset)
     end
+
+    it "applies a three fifths column in shorthand with the default grid" do
+      ruleset = "width: calc(60% - 32px); " +
+        "float: left; " +
+        "margin-left: 20px;"
+
+      expect(".grid-column-3-of-5-shorthand").to have_ruleset(ruleset)
+    end
   end
 
   context "called with a custom grid" do
@@ -54,6 +62,14 @@ describe "grid-column" do
         "margin-left: 1em;"
 
       expect(".grid-column-6-of-6").to have_ruleset(ruleset)
+    end
+
+    it "applies a three fifths column in shorthand" do
+      ruleset = "width: calc(60% - 1.6em); " +
+        "float: left; " +
+        "margin-left: 1em;"
+
+      expect(".grid-column-3-of-5-shorthand-six-grid").to have_ruleset(ruleset)
     end
   end
 

--- a/spec/neat/mixins/grid_push_spec.rb
+++ b/spec/neat/mixins/grid_push_spec.rb
@@ -23,6 +23,12 @@ describe "grid-push" do
 
       expect(".grid-push-6-default").to have_rule(rule)
     end
+
+    it "adds margin for negative six columns" do
+      rule = "margin-left: calc(-50% - 10px + 40px)"
+
+      expect(".grid-push-neg-6-default").to have_rule(rule)
+    end
   end
 
   context "called with custom settings" do
@@ -42,6 +48,12 @@ describe "grid-push" do
       rule = "margin-left: calc(50% - 3rem + 4rem)"
 
       expect(".grid-push-3-six").to have_rule(rule)
+    end
+
+    it "adds margin for negative three columns" do
+      rule = "margin-left: calc(-50% - 1rem + 4rem)"
+
+      expect(".grid-push-neg-3-six").to have_rule(rule)
     end
   end
 end


### PR DESCRIPTION
- `grid-push` accepst negative values. This is now tested.
- `grid-column` shorthand (`3 of 5` for example) is now tested with both the
  default and custom grids.