### PR TITLE
Add `grid-collapse` to allow nested grids

### DIFF
--- a/contrib/index.html
+++ b/contrib/index.html
@@ -64,6 +64,19 @@
           <h3>Grid Media Queries</h3>
         </div>
         <div class="grid-column--media-3-to-6 box"></div>
+        <div class="grid__column--full">
+          <h3>Grid collapse</h3>
+        </div>
+        <div class="grid__column--thirds box"></div>
+        <div class="grid__column--thirds">
+            <div class="grid-collapse">
+              <div class="grid__column--thirds box"></div>
+              <div class="grid__column--thirds box"></div>
+              <div class="grid__column--thirds box"></div>
+            </div>
+        </div>
+        <div class="grid__column--thirds box"></div>
+        <div class="grid__column--full">
       </div>
     </main>
   </body>

--- a/contrib/patterns/_grid-collapse.scss
+++ b/contrib/patterns/_grid-collapse.scss
@@ -1,0 +1,3 @@
+.grid-collapse {
+  @include grid-collapse;
+}

--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -6,6 +6,7 @@
 @import "patterns/box";
 @import "patterns/global";
 @import "patterns/grid";
+@import "patterns/grid-collapse";
 @import "patterns/grid-nested";
 @import "patterns/grid-push";
 @import "patterns/grid-shift";

--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -13,6 +13,7 @@
 @import "neat/functions/neat-parse-columns";
 @import "neat/functions/neat-parse-media";
 
+@import "neat/mixins/grid-collapse";
 @import "neat/mixins/grid-column";
 @import "neat/mixins/grid-container";
 @import "neat/mixins/grid-media";

--- a/core/neat/mixins/_grid-collapse.scss
+++ b/core/neat/mixins/_grid-collapse.scss
@@ -1,0 +1,31 @@
+@charset "UTF-8";
+/// Creates collapsed grid object that consumes the gutters of its container.
+///
+/// @argument {map} $grid [$neat-grid]
+///   The grid used to determine gutter size.
+///
+/// @example scss
+///   .element {
+///     @include grid-collapse;
+///   }
+///
+/// @example css
+///   .element {
+///     float: left;
+///     margin-left: -20px;
+///     margin-right: -20px;
+///     width: calc(100% + 40px);
+///   }
+
+@mixin grid-collapse($grid: $neat-grid) {
+  $_grid-gutter: _retrieve-neat-setting($grid, gutter);
+
+  @if unit($_grid-gutter) == "%" {
+    @warn "`grid-collapse` is not compatible with percentage based gutters.";
+  }
+
+  float: left;
+  margin-left: -($_grid-gutter);
+  margin-right: -($_grid-gutter);
+  width: calc(100% + #{($_grid-gutter * 2)});
+}

--- a/spec/fixtures/mixins/grid-collapse.scss
+++ b/spec/fixtures/mixins/grid-collapse.scss
@@ -1,0 +1,14 @@
+@import "setup";
+
+$custom-grid: (
+  columns: 6,
+  gutter: 4rem,
+);
+
+.grid-collapse-default {
+  @include grid-collapse;
+}
+
+.grid-collapse-custom {
+  @include grid-collapse($custom-grid);
+}

--- a/spec/neat/mixins/grid_collapse_spec.rb
+++ b/spec/neat/mixins/grid_collapse_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe "grid-collapse" do
+  before(:all) do
+    ParserSupport.parse_file("mixins/grid-collapse")
+  end
+
+  context "called with default settings" do
+    it "adds margin for just the gutter with no specified column" do
+      ruleset = "float: left; " +
+        "margin-left: -20px; " +
+        "margin-right: -20px; " +
+        "width: calc(100% + 40px);"
+      expect(".grid-collapse-default").to have_ruleset(ruleset)
+    end
+  end
+
+  context "called with custom settings" do
+    it "adds margin for just the gutter with no specified column" do
+      ruleset = "float: left; " +
+        "margin-left: -4rem; " +
+        "margin-right: -4rem; " +
+        "width: calc(100% + 8rem);"
+
+      expect(".grid-collapse-custom").to have_ruleset(ruleset)
+    end
+  end
+end


### PR DESCRIPTION
An alternate configuration to [https://github.com/thoughtbot/neat/pull/486]. This configuration instead creates a simple grid object that uses negative margin to eat the gutters of its parent. nom nom nom. 

<img width="1185" alt="screen shot 2016-07-31 at 8 48 50 pm" src="https://cloud.githubusercontent.com/assets/2489247/17280564/3b9eecd0-5760-11e6-9561-df3152234107.png">
