### PR TITLE
Add style property to package.json, allowing for easier imports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "http://thoughtbot.com"
   },
   "main": "index.js",
-  "style": "app/assets/stylesheets/_neat.scss",
+  "style": "core/_bourbon.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/thoughtbot/neat.git"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "http://thoughtbot.com"
   },
   "main": "index.js",
-  "style": "core/_bourbon.scss",
+  "style": "style": "app/assets/stylesheets/_neat.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/thoughtbot/neat.git"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "http://thoughtbot.com"
   },
   "main": "index.js",
-  "style": "style": "app/assets/stylesheets/_neat.scss",
+  "style": "app/assets/stylesheets/_neat.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/thoughtbot/neat.git"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "http://thoughtbot.com"
   },
   "main": "index.js",
+  "style": "app/assets/stylesheets/_neat.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/thoughtbot/neat.git"


### PR DESCRIPTION
When installed via npm, a style property in package.json allows this module to be easily imported when using tools such as [npm-sass](https://github.com/lennym/npm-sass) or [sass-module-importer](https://www.npmjs.com/package/sass-module-importer).

Apparently the "style" key is not a standard, but it is a growing trend. Here's a StackOverflow thread on the subject: http://stackoverflow.com/questions/32037150/style-field-in-package-json