### PR TITLE
Update node-sass version to 4.1.1 in order to support binaries for Alpine Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "echo \"No test specified\""
   },
   "dependencies": {
-    "node-sass": "^3.4"
+    "node-sass": "^4.1.1"
   },
   "devDependencies": {
     "gulp": "^3.9",


### PR DESCRIPTION
This solves https://github.com/thoughtbot/neat/issues/519.

We currently use version ^3.4 which is actually version 3.13.1 and according to the release notes of node-sass there are no breaking changes what so ever: https://github.com/sass/node-sass/releases/tag/v4.0.0