### PR TITLE
Fix stylesheets_directory path

### DIFF
--- a/lib/neat/generator.rb
+++ b/lib/neat/generator.rb
@@ -62,7 +62,7 @@ module Neat
     end
 
     def stylesheets_directory
-      File.join(top_level_directory, "app", "assets", "stylesheets")
+      File.join(top_level_directory, "core")
     end
 
     def top_level_directory


### PR DESCRIPTION
- `app/assets/stylesheets/` was the old path from v1.x
- As of 2.0, the path where the Neat library lives is `core/`

This was causing the `neat install` command from Neat’s CLI to install a `neat/` directory without any of the library files in it.