### PR TITLE
Relocate neat defaults and alter default grid inheritence

### DIFF
--- a/core/neat/functions/_retrieve-neat-settings.scss
+++ b/core/neat/functions/_retrieve-neat-settings.scss
@@ -13,6 +13,14 @@
 /// @access private
 
 @function _retrieve-neat-setting($grid, $setting) {
+  $_neat-grid-defaults: (
+    columns: 12,
+    gutter: 20px,
+    media: null,
+    color: rgba(#00d4ff, 0.25),
+    direction: ltr,
+  );
+
   $_grid-settings: map-merge($_neat-grid-defaults, $grid);
   @return map-get($_grid-settings, $setting);
 }

--- a/core/neat/functions/_retrieve-neat-settings.scss
+++ b/core/neat/functions/_retrieve-neat-settings.scss
@@ -13,13 +13,13 @@
 /// @access private
 
 @function _retrieve-neat-setting($grid, $setting) {
-  $_neat-grid-defaults: (
+  $_neat-grid-defaults: map-merge((
     columns: 12,
     gutter: 20px,
     media: null,
     color: rgba(#00d4ff, 0.25),
     direction: ltr,
-  );
+  ), $neat-grid);
 
   $_grid-settings: map-merge($_neat-grid-defaults, $grid);
   @return map-get($_grid-settings, $setting);

--- a/core/neat/functions/_retrieve-neat-settings.scss
+++ b/core/neat/functions/_retrieve-neat-settings.scss
@@ -1,5 +1,6 @@
 @charset "UTF-8";
-/// Return a Neat setting.
+/// This function recives a grid map and merges it with Neat's defauls.
+/// It then returns the value of the property that has been passed to it.
 ///
 /// @argument {map} $grid
 ///

--- a/core/neat/settings/_settings.scss
+++ b/core/neat/settings/_settings.scss
@@ -1,34 +1,4 @@
 @charset "UTF-8";
-/// Neat’s default grid.
-///
-/// @group settings
-///
-/// @type map
-///
-/// @name Default settings
-///
-/// @property {number (unitless)} columns [12]
-///   Default number of the total grid columns.
-///
-/// @property {number (with unit)} gutter [20px]
-///   Default grid gutter width between columns.
-///
-/// @property {string | number (with unit)} media [null]
-///   Grid media query.
-///
-/// @property {color} color [rgba(#00d4ff, 0.25)]
-///   Default visual grid color.
-///
-/// @access private
-
-$_neat-grid-defaults: (
-  columns: 12,
-  gutter: 20px,
-  media: null,
-  color: rgba(#00d4ff, 0.25),
-  direction: ltr,
-);
-
 /// This variable is a sass map that overrides Neat's default grid settings.
 /// Use this to define your project's grid properties incluting gutters and
 /// total column count.


### PR DESCRIPTION
These changes move the neat-grid-defaults which originally resided in the core variables file to within retrieve-neat-setting. This change in conjunction with the fact that `$neat-grid` is defined with `!default` effectively means that there is no exposed variables within the entire library, but thats a bit of an exaggeration all things considered.

Either way, addresses: https://github.com/thoughtbot/neat/issues/531

These changes also alter the inheritance of grids passed directly in to mixins via the second perimeter. Custom grids, i.e. `$my-custom-grid-blah-blah` originally inherited any undefined properties from `$_neat-grid-defaults`. Ignoring any changes made to the 'main' grid, `$neat-grid`.

Custom grids will now inherit any undefined properties that are defined in `$neat-grid`, and then properties left still undefined will inherit from `$_neat-grid-defaults`.

Addresses: https://github.com/thoughtbot/neat/issues/533