### PR TITLE
Inherit undefined media grid properties from global neat-grid

### DIFF
--- a/core/_neat.scss
+++ b/core/_neat.scss
@@ -11,6 +11,7 @@
 @import "neat/functions/neat-column-width";
 @import "neat/functions/neat-column-ratio";
 @import "neat/functions/neat-float-direction";
+@import "neat/functions/neat-merge-defaults";
 @import "neat/functions/neat-opposite-direction";
 @import "neat/functions/neat-parse-columns";
 @import "neat/functions/neat-parse-media";

--- a/core/neat/functions/_neat-merge-defaults.scss
+++ b/core/neat/functions/_neat-merge-defaults.scss
@@ -1,0 +1,23 @@
+@charset "UTF-8";
+/// Apply Neat's default properties to undefined values within a map.
+///
+/// @argument {map} $grid
+///
+/// @return {map}
+///
+/// @example scss
+///   _retrieve-neat-setting($neat-grid)
+///
+/// @access private
+
+@function _neat-merge-defaults($grid) {
+  $_merged-grid: map-merge((
+    columns: 12,
+    gutter: 20px,
+    media: null,
+    color: rgba(#00d4ff, 0.25),
+    direction: ltr,
+  ), $grid);
+
+  @return $_merged-grid;
+}

--- a/core/neat/functions/_retrieve-neat-settings.scss
+++ b/core/neat/functions/_retrieve-neat-settings.scss
@@ -14,14 +14,6 @@
 /// @access private
 
 @function _retrieve-neat-setting($grid, $setting) {
-  $_neat-grid-defaults: map-merge((
-    columns: 12,
-    gutter: 20px,
-    media: null,
-    color: rgba(#00d4ff, 0.25),
-    direction: ltr,
-  ), $neat-grid);
-
-  $_grid-settings: map-merge($_neat-grid-defaults, $grid);
+  $_grid-settings: map-merge(_neat-merge-defaults($neat-grid), $grid);
   @return map-get($_grid-settings, $setting);
 }

--- a/core/neat/mixins/_grid-media.scss
+++ b/core/neat/mixins/_grid-media.scss
@@ -50,7 +50,7 @@
 
   @media #{$_query} {
     $_default-neat-grid: $neat-grid;
-    $neat-grid: $grid !global;
+    $neat-grid: map-merge($neat-grid, $grid) !global;
     @content;
     $neat-grid: $_default-neat-grid !global;
   }


### PR DESCRIPTION
Currently a custom grid used with the `grid-media()` mixin will inherit any undefined properties from neat's internal default grid and not the globally defined `$neat-grid` which is user accessible. This issue was addressed in [https://github.com/thoughtbot/neat/issues/532]. Because of this the following changes have been addressed in this PR.

1. Since the defaults are now being used in multiple locations, I have abstracted them in to their own function, the newly dubbed `_neat-merge-defaults`. This function accepts a single map, and merges it with the neat's defaults to fill in any missing pieces.
2. Secondly, the `grid-media()` mixin now performs an operation of merging the mixin it has been passed with the user defined `$neat-grid` before falling back to the neat internal defaults.

I was able to replicate the original issue in the contrib pages as below:

## Sass grids
```scss

$neat-grid: (
  columns: 12,
  gutter: 40px,
);

$specific-neat-grid: (
  columns: 7,
  media: "only screen and (min-width: 1000px) and (max-width: 1100px)",
);
```

## Original behavior

<img width="1076" alt="screen shot 2017-02-09 at 10 44 56 am" src="https://cloud.githubusercontent.com/assets/2489247/22791505/951e950a-eeb7-11e6-839d-9ed8b5dd189d.png">

In this screenshot, `$specific-neat-grid` has engaged, based on it's `media` attribute. Since it does not have a `gutter` set, the grid falls back to the default. Even though `$neat-grid` has a gutter defined, the library skips it and goes straight back to neat's default `20px`. Not really *wrong* but feels unexpected. This could be issue could be eschewed by adding `gutter: 40px,` to `$specific-neat-grid`.

## New Behavior

<img width="1074" alt="screen shot 2017-02-09 at 10 45 12 am" src="https://cloud.githubusercontent.com/assets/2489247/22791521/a08803ea-eeb7-11e6-93c6-f8ada260770f.png">

In this example, `$specific-neat-grid`'s undefined `gutter` property now inherits from `$neat-grid` prior to falling back to the internal neat default. The column now observes the `40px` gutter of its predecessors.

---

Address: https://github.com/thoughtbot/neat/issues/532