### PR TITLE
Configure hound to ignore `///` comment style

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -167,6 +167,10 @@ linters:
     enabled: true
     style: one_space
 
+  SpaceAfterComment:
+    enabled: false
+    allow_empty_comments: true
+
   SpaceAfterPropertyColon:
     enabled: true
     style: one_space


### PR DESCRIPTION
Sassdoc uses a tripple dash comment style to mark its content.