### PR TITLE
Add versioned sassdoc for ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,14 @@
 dependencies:
   override:
     - bundle install
-    - npm install -g sassdoc
+    - npm install -g sassdoc@2.2.0
 general:
   branches:
     ignore:
       - gh-pages
+machine:
+  node:
+    version: 6.9.5
 test:
   override:
     - bundle exec rake


### PR DESCRIPTION
We have been encountering repeated failures based on our ci tests using sassdoc. this may be due to a version bump so this change implements a specified version of sassdoc to ci, `v2.1.2`.