### PR TITLE
Simplify the gradient style of grid-visual

### DIFF
--- a/core/neat/mixins/_grid-visual.scss
+++ b/core/neat/mixins/_grid-visual.scss
@@ -32,11 +32,8 @@
   $_grid-visual-object: () !default;
   $_grid-visual:
     $color,
-    $color 1px,
-    transparent 1px,
+    $color $_grid-gutter,
     transparent $_grid-gutter,
-    $color calc(#{$_grid-gutter} + 1px),
-    transparent calc(#{$_grid-gutter} + 2px),
   ;
 
   @for $i from 1 to $_grid-columns {
@@ -51,36 +48,20 @@
     $_grid-visual-loop-list:
       transparent calc(#{$location}),
       $color calc(#{$location}),
-      $color calc(#{$location} + 1px),
-      transparent calc(#{$location} + 1px),
-      transparent calc(#{$location} + #{$_grid-gutter}),
       $color calc(#{$location} + #{$_grid-gutter}),
-      $color calc(#{$location} + #{$_grid-gutter} + 1px),
-      transparent calc(#{$location} + #{$_grid-gutter} + 1px),
+      transparent calc(#{$location} + #{$_grid-gutter}),
     ;
 
     $_grid-visual: _neat-append-grid-visual($_grid-visual, $_grid-visual-loop-list);
   }
 
   $_grid-visual-loop-list:
-    transparent calc(100% - #{$_grid-gutter}),
-    $color calc(100% - #{$_grid-gutter}),
-    $color calc(100% - #{$_grid-gutter} + 1px),
-    transparent calc(100% - #{$_grid-gutter} + 1px),
-    transparent calc(100% - 1px),
-    $color calc(100% - 1px),
+      transparent calc(100% - #{$_grid-gutter}),
+      $color calc(100% - #{$_grid-gutter}),
+      $color calc(100%),
   ;
 
   $_grid-visual: _neat-append-grid-visual($_grid-visual, $_grid-visual-loop-list);
 
-  background-image:
-    linear-gradient(to right, $_grid-visual),
-    linear-gradient(to bottom,
-      $color,
-      $color 1px,
-      transparent 1px,
-      transparent calc(100% - 1px),
-      $color calc(100% - 1px),
-      $color
-  );
+  background-image: linear-gradient(to right, $_grid-visual);
 }


### PR DESCRIPTION
Currently quite a few browsers have issues with the complexity of the gradient.

https://github.com/thoughtbot/neat/issues/539

## Safari

![screen shot 2017-02-15 at 5 18 39 pm](https://cloud.githubusercontent.com/assets/2489247/22998174/940c0620-f3a3-11e6-8a43-f0c2d44b00e0.png)

## Firefox

<img width="1065" alt="screen shot 2017-02-15 at 5 23 14 pm" src="https://cloud.githubusercontent.com/assets/2489247/22998175/943f57f0-f3a3-11e6-97f3-2f366c5b2a2c.png">

# Chrome

<img width="1019" alt="screen shot 2017-02-15 at 5 24 36 pm" src="https://cloud.githubusercontent.com/assets/2489247/22998228/d1c79678-f3a3-11e6-946a-782da24bf4a2.png">

