### PR TITLE
Update grid collapse documentation

### DIFF
--- a/core/neat/mixins/_grid-collapse.scss
+++ b/core/neat/mixins/_grid-collapse.scss
@@ -17,7 +17,6 @@
 ///
 /// @example css
 ///   .element {
-///     float: left;
 ///     margin-left: -20px;
 ///     margin-right: -20px;
 ///     width: calc(100% + 40px);


### PR DESCRIPTION
Missed removing `float: left` from docs.