### PR TITLE
Simplify grid-visual for consistent cross-browser behaviour

### DIFF
--- a/core/neat/mixins/_grid-visual.scss
+++ b/core/neat/mixins/_grid-visual.scss
@@ -19,7 +19,7 @@
 ///
 /// @example css
 ///   .element {
-///     background-image: linear-gradient( … ) ;
+///     background-image: repeating-linear-gradient( … ) ;
 ///   }
 
 @mixin grid-visual($color: null, $grid: $neat-grid) {
@@ -29,39 +29,13 @@
 
   $_grid-columns: _retrieve-neat-setting($grid, columns);
   $_grid-gutter: _retrieve-neat-setting($grid, gutter);
-  $_grid-visual-object: () !default;
+  $_grid-visual-column: "#{_neat-column-width($grid, 1)} + #{$_grid-gutter}";
   $_grid-visual:
-    $color,
-    $color $_grid-gutter,
+    transparent,
     transparent $_grid-gutter,
+    $color $_grid-gutter,
+    $color calc(#{$_grid-visual-column}),
   ;
 
-  @for $i from 1 to $_grid-columns {
-    $_grid-visual-local: (
-      #{$i}: "#{_neat-column-width($grid, $i)} + #{$_grid-gutter}",
-    );
-
-    $_grid-visual-object: map-merge($_grid-visual-object, $_grid-visual-local);
-  }
-
-  @each $stop, $location in $_grid-visual-object {
-    $_grid-visual-loop-list:
-      transparent calc(#{$location}),
-      $color calc(#{$location}),
-      $color calc(#{$location} + #{$_grid-gutter}),
-      transparent calc(#{$location} + #{$_grid-gutter}),
-    ;
-
-    $_grid-visual: _neat-append-grid-visual($_grid-visual, $_grid-visual-loop-list);
-  }
-
-  $_grid-visual-loop-list:
-      transparent calc(100% - #{$_grid-gutter}),
-      $color calc(100% - #{$_grid-gutter}),
-      $color calc(100%),
-  ;
-
-  $_grid-visual: _neat-append-grid-visual($_grid-visual, $_grid-visual-loop-list);
-
-  background-image: linear-gradient(to right, $_grid-visual);
+  background-image: repeating-linear-gradient(to right, $_grid-visual);
 }


### PR DESCRIPTION
The gradient style of `grid-visual` behaves inconsistent across browsers and currently has major rendering issues on Chrome. In the same time having the gutters painted creates a bit of confusion, where I think users expect the paint to be applied to the columns. (mainly when coming from a design tool like Sketch or Illustrator where the grid layout highlights the columns and not the gutters).

This mainly solves [#539](https://github.com/thoughtbot/neat/issues/539) but in the same time updates the `grid-visual` to a column-based painting rather than a gutter-based painting.

We basically go from this:
<img width="1010" alt="current-gird-visual-chrome" src="https://cloud.githubusercontent.com/assets/4587864/24292487/75931144-1085-11e7-91ca-c307c707ad7c.png">

to this:
<img width="1010" alt="updated-grid-visual-chrome" src="https://cloud.githubusercontent.com/assets/4587864/24292507/84b1d9a8-1085-11e7-8b04-a4522ead7c4e.png">

This update simplifies the `grid-visual` mixin by introducing the `repeating-linear-gradient(...)` property which allows us to consider the width of only a single column, instead of looping through each grid-column to create the `linear-gradient(...)`. Also the `calc()` function has better cross browser integration and consistency when used within the `repeating-linear-gradient` property.
