### PR TITLE
Fix Sass path

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -1,7 +1,4 @@
+require "sass"
 require "neat/generator"
 
-neat_path = File.expand_path("../../core", __FILE__)
-ENV["SASS_PATH"] = [
-  ENV["SASS_PATH"],
-  neat_path,
-].compact.join(File::PATH_SEPARATOR)
+Sass.load_paths << File.expand_path("../../core", __FILE__)


### PR DESCRIPTION
may be related to #546 

`ENV['SASS_PATH']` is not loaded correctly depending on the order in which gems are read.