### PR TITLE
Remove unitless comparison

### DIFF
--- a/core/neat/functions/_neat-column-width.scss
+++ b/core/neat/functions/_neat-column-width.scss
@@ -16,7 +16,7 @@
   $_column-ratio: _neat-column-ratio($grid, $columns);
   $_gutter: _retrieve-neat-setting($grid, gutter);
 
-  @if $_gutter == 0 {
+  @if $_gutter == 0px {
     @return unquote("#{percentage($_column-ratio)}");
   } @else {
     $_gutter-affordance: $_gutter + ($_gutter * $_column-ratio);


### PR DESCRIPTION
This addresses a change to Sass that raises this deprecation warning in apps running Neat:

```
DEPRECATION WARNING on line 19 of …/core/neat/functions/_neat-column-width.scss:
The result of `0px == 0` will be `false` in future releases of Sass. Unitless numbers will no longer be equal to the same numbers with units.
```

More info at https://github.com/sass/sass/issues/1496.