### PR TITLE
Fix path

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "http://thoughtbot.com"
   },
   "main": "index.js",
-  "style": "app/assets/stylesheets/_neat.scss",
+  "style": "core/_neat.scss",
   "repository": {
     "type": "git",
     "url": "https://github.com/thoughtbot/neat.git"


### PR DESCRIPTION
The original change was to add a `style` property, but it appears to
have gone through a rebase or other conflict and was left using the
wrong path.

History:

1. https://github.com/thoughtbot/neat/commit/99f9255a55eb5d016042ca6e129572803de0a6a8
2. https://github.com/thoughtbot/neat/commit/a4820d74180ddaa6b7cd89610f5bf045ff774052
3. https://github.com/thoughtbot/neat/commit/2666dc829133578f0a629595cb788b8da7fa1cd0
4. https://github.com/thoughtbot/neat/commit/5f15317c170dbf98a482091d5879cf19564a8298
