### PR TITLE
Use Sass.load_paths instead of SASS_PATH env

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -1,7 +1,4 @@
+require "sass"
 require "neat/generator"
 
-neat_path = File.expand_path("../../core", __FILE__)
-ENV["SASS_PATH"] = [
-  ENV["SASS_PATH"],
-  neat_path,
-].compact.join(File::PATH_SEPARATOR)
+Sass.load_paths << File.expand_path("../../core", __FILE__)


### PR DESCRIPTION
#The SASS_PATH environment variable is not intended to be set by another
library but rather by consumers of Sass. Since the environment variable
is only read in once at the first time `load_paths` is called.

This was causing an error where, if a user had another gem such as
`bootstrap-sass` and it was being loaded before `neat` was, the
modifications to `SASS_PATH` we were making were never read in, so the
neat files would never be found.

See https://github.com/sass/sass/blob/1b628f03b9361fa6047097c9fd0d01b21247b8f3/lib/sass.rb#L20-L43