### PR TITLE
Add CODE_OF_CONDUCT.md

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 bin/
 bower.json
 circle.yml
+CODE_OF_CONDUCT.md
 contrib/
 CONTRIBUTING.md
 Gemfile

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+By participating in this project, you agree to abide by the
+[thoughtbot code of conduct][tb-coc].
+
+[tb-coc]: https://thoughtbot.com/open-source-code-of-conduct


### PR DESCRIPTION
GitHub has a new feature that indicates if a project has a code of
conduct. We already had one, linked from `CONTRIBUTING.md`. This commit
just duplicates that link in a place where GitHub can find it.