### PR TITLE
Fixing unescaped multiline string.

### DIFF
--- a/core/neat/mixins/_grid-container.scss
+++ b/core/neat/mixins/_grid-container.scss
@@ -19,8 +19,8 @@
 
 @mixin grid-container($grid: $neat-grid) {
   @if $grid != $neat-grid {
-    @warn "`grid-container` does not use grid propertes.
-      Custom grids do not need to be passed in to this mixin.";
+    @warn "`grid-container` does not use grid properties." +
+          "Custom grids do not need to be passed in to this mixin.";
   }
 
   &::after {


### PR DESCRIPTION
Just getting rid of the deprecation message as it's been getting on my nerves.

Related to:

* https://github.com/sass/sass/issues/1302
* https://github.com/sass/sass/issues/1237
* https://github.com/sass/libsass/issues/942

- [ ] Commit message has a short title & issue references
(Sorry, couldn't find an issue about this)

- [ ] Commits are squashed
(There is only one)

- [x] The build will pass (run `bundle exec rake`).