### PR TITLE
Make 'calc' for width and margin-left of grid-column conditional on gutter width

### DIFF
--- a/core/neat/mixins/_grid-column.scss
+++ b/core/neat/mixins/_grid-column.scss
@@ -33,7 +33,15 @@
   $_grid-columns: _retrieve-neat-setting($grid, columns);
   $_grid-gutter: _retrieve-neat-setting($grid, gutter);
 
-  width: calc(#{_neat-column-width($grid, $columns)});
+  @if $_grid-gutter == 0 {
+    width: #{_neat-column-width($grid, $columns)};
+  } @else {
+    width: calc(#{_neat-column-width($grid, $columns)});
+  }
+
   float: _neat-float-direction($grid);
-  margin-#{_neat-float-direction($grid)}: $_grid-gutter;
+
+  @if $_grid-gutter != 0 {
+    margin-#{_neat-float-direction($grid)}: $_grid-gutter;
+  }
 }

--- a/spec/fixtures/mixins/grid-column.scss
+++ b/spec/fixtures/mixins/grid-column.scss
@@ -10,6 +10,11 @@ $seventeen-grid: (
   gutter: 10px,
 );
 
+$gutterless-twelve-grid: (
+  columns: 12,
+  gutter: 0,
+);
+
 .grid-column-1-of-default {
   @include grid-column(1);
 }
@@ -54,4 +59,14 @@ $seventeen-grid: (
   @include grid-column(12, $seventeen-grid);
 }
 
+.grid-column-1-of-gutterless-12 {
+  @include grid-column(1, $gutterless-twelve-grid);
+}
 
+.grid-column-6-of-gutterless-12 {
+  @include grid-column(6, $gutterless-twelve-grid);
+}
+
+.grid-column-12-of-gutterless-12 {
+  @include grid-column(12, $gutterless-twelve-grid);
+}

--- a/spec/neat/mixins/grid_column_spec.rb
+++ b/spec/neat/mixins/grid_column_spec.rb
@@ -98,4 +98,32 @@ describe "grid-column" do
       expect(".grid-column-13-of-17").to have_ruleset(ruleset)
     end
   end
+
+  context "called with a gutterless grid" do
+    marginLeft = "margin-left: 0;"
+
+    it "applies one column" do
+      ruleset = "width: 8.33333%; " +
+        "float: left;"
+
+      expect(".grid-column-1-of-gutterless-12").to have_ruleset(ruleset)
+      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(marginLeft)
+    end
+
+    it "applies six column" do
+      ruleset = "width: 50%; " +
+        "float: left;"
+
+      expect(".grid-column-6-of-gutterless-12").to have_ruleset(ruleset)
+      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(marginLeft)
+    end
+
+    it "applies twelve column" do
+      ruleset = "width: 100%; " +
+        "float: left;"
+
+      expect(".grid-column-12-of-gutterless-12").to have_ruleset(ruleset)
+      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(marginLeft)
+    end
+  end
 end

--- a/spec/neat/mixins/grid_column_spec.rb
+++ b/spec/neat/mixins/grid_column_spec.rb
@@ -100,14 +100,14 @@ describe "grid-column" do
   end
 
   context "called with a gutterless grid" do
-    marginLeft = "margin-left: 0;"
+    margin_left = "margin-left: 0;"
 
     it "applies one column" do
       ruleset = "width: 8.33333%; " +
         "float: left;"
 
       expect(".grid-column-1-of-gutterless-12").to have_ruleset(ruleset)
-      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(marginLeft)
+      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(margin_left)
     end
 
     it "applies six column" do
@@ -115,7 +115,7 @@ describe "grid-column" do
         "float: left;"
 
       expect(".grid-column-6-of-gutterless-12").to have_ruleset(ruleset)
-      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(marginLeft)
+      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(margin_left)
     end
 
     it "applies twelve column" do
@@ -123,7 +123,7 @@ describe "grid-column" do
         "float: left;"
 
       expect(".grid-column-12-of-gutterless-12").to have_ruleset(ruleset)
-      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(marginLeft)
+      expect(".grid-column-1-of-gutterless-12").not_to have_ruleset(margin_left)
     end
   end
 end


### PR DESCRIPTION
This PR added conditional inclusion for the 'calc' function in the width of grid-columns based on the existence of a gutter width.  This fixes issues with old Chrome for a project I am working on.

If desired, I can expand it further to include the other uses of the 'calc' and margin-left outside of the grid-columns file.

- [x] Commit message has a short title & issue references
- [ ] Commits are squashed
- [x] The build will pass (run `bundle exec rake`).

More info can be found by clicking the "guidelines for contributing" link above.
