### PR TITLE
Fix AND operator in conditional

### DIFF
--- a/app/assets/stylesheets/grid/_omega.scss
+++ b/app/assets/stylesheets/grid/_omega.scss
@@ -104,7 +104,7 @@
         clear: $opposite-direction;
       }
     }
-  } @else if type-of($query) == number && unit($query) == "n" {
+  } @else if type-of($query) == number and unit($query) == "n" {
     &:nth-child(#{$query}+1) {
       clear: $opposite-direction;
     }


### PR DESCRIPTION
This fixes the following Sass warning:
```
WARNING on line 107, column 40 of app/assets/stylesheets/grid/_omega.scss:
In Sass, "&&" means two copies of the parent selector. You probably want to use "and" instead.
```