### PR TITLE
Adding parentheses to if-condition to fix compile issue

### DIFF
--- a/core/neat/functions/_neat-parse-columns.scss
+++ b/core/neat/functions/_neat-parse-columns.scss
@@ -16,7 +16,7 @@
   @if length($span) == 3 {
     $_total-columns: nth($span, 3);
     @return $_total-columns;
-  } @else if length($span) == 2 or if length($span) >= 3 {
+  } @else if length($span) == 2 or if(length($span) >= 3) {
     @error "`$column` should contain 2 values, seperated by an `of`";
   }
 }


### PR DESCRIPTION
This PR added conditional inclusion for the 'calc' function in the width of grid-columns based on the existence of a gutter width. This fixes issues with old Chrome for a project I am working on.

If desired, I can expand it further to include the other uses of the 'calc' and margin-left outside of the grid-columns file.

- [ ] Commit message has a short title & issue references

- [ ] Commits are squashed

- [x] The build will pass (run bundle exec rake).

More info can be found by clicking the "guidelines for contributing" link above.