### PR TITLE
Register Neat with asset pipeline when requisite

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -1,4 +1,12 @@
 require "sass"
 require "neat/generator"
 
-Sass.load_paths << File.expand_path("../../core", __FILE__)
+module Neat
+  if defined?(Rails) && defined?(Rails::Engine)
+    class Engine < ::Rails::Engine
+      config.assets.paths << File.expand_path("../../core", __FILE__)
+    end
+  else
+    Sass.load_paths << File.expand_path("../../core", __FILE__)
+  end
+end


### PR DESCRIPTION
This change is entirely based on a recent change to Bourbon (commit [8257c6](https://github.com/thoughtbot/bourbon/commit/8257c683f8a250c06407f66d077dfbe6ce6595b0#diff-255680ed330f8b6f9e378309fa614e28)) that will register Neat with the Rails asset pipeline.

This resolves a compatibility issue with Sprockets 4 where the SASS processor source map does not include `Sass.load_paths`.

It may be the issue also lies in the Sprockets court given this is an incompatibility introduced in v4, which is still in beta. However, it may be worthwhile to account for it on this side too to maintain as much compatibility as possible.
