### PR TITLE
Register neat with config.assets when in Rails

### DIFF
--- a/lib/neat.rb
+++ b/lib/neat.rb
@@ -1,4 +1,12 @@
 require "sass"
 require "neat/generator"
 
-Sass.load_paths << File.expand_path("../../core", __FILE__)
+module Neat
+  if defined?(Rails::Engine)
+    class Engine < ::Rails::Engine
+      config.assets.paths << File.expand_path("../core", __dir__)
+    end
+  else
+    Sass.load_paths << File.expand_path("../core", __dir__)
+  end
+end


### PR DESCRIPTION
Along the same lines as https://github.com/thoughtbot/bourbon/pull/1053/8257c683f8a250c06407f66d077dfbe6ce6595b0, using `Sass.load_paths` won't work if we happen to be using sassc-rails instead of sass-rails. I ran into this when I was testing out https://github.com/thoughtbot/suspenders/pull/936. We may also want to think about removing the `sass` dependency listed in the gemspec to neat and bourbon. If we are using `sassc`, we probably don't also want `sass`.