### PR TITLE
Fix the link of logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Neat is maintained by the thoughtbot design team. It is funded by
 [thoughtbot, inc.][thoughtbot] and the names and logos for thoughtbot are
 trademarks of thoughtbot, inc.
 
-[<img src="http://presskit.thoughtbot.com/images/signature.svg" width="250" alt="thoughtbot logo">][thoughtbot]
+[![thoughtbot logo](https://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg)][thoughtbot]
 
 We love open-source software! See [our other projects][community] or
 [hire us][hire] to design, develop, and grow your product.


### PR DESCRIPTION
Hi, everyone. 👋

I just found that the link of logo is broken:
<img width="574" alt="screen shot 2019-02-15 at 9 05 53 pm" src="https://user-images.githubusercontent.com/5573816/52858627-9f904180-3165-11e9-8ab5-ed621e6e08b1.png">

So I copied the link from factory_bot's README and fixed it. 
Please take a look. Thank you.
