### PR TITLE
Replace EOLed ruby-sass with sassc Gem

### DIFF
--- a/neat.gemspec
+++ b/neat.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "scss_lint", "~> 0.44"
-  s.add_runtime_dependency "sass", "~> 3.4"
+  s.add_runtime_dependency "sassc", "~> 2.0"
   s.add_runtime_dependency "thor", "~> 0.19"
   s.authors = [
     "Joel Oliveira",


### PR DESCRIPTION
The Ruby Sass gem has reached end-of-life. The least disruptive path
forward looks like updating to use the C-based `sassc` gem.

[Sass announcement](https://sass-lang.com/blog/posts/7828841)

Close #669

Got some code for us? Awesome 🎊!

Please include a description of your change and the problem it solves. Then check your PR against this list. Thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed
- [x] The build will pass (run `bundle exec rake`).

More info can be found by clicking the "guidelines for contributing" link above.
