### PR TITLE
Fix typo in docs

### DIFF
--- a/core/neat/mixins/_grid-column.scss
+++ b/core/neat/mixins/_grid-column.scss
@@ -9,7 +9,7 @@
 ///   Specifies the number of columns an element should span based on the total
 ///   columns of the grid.
 ///
-///   This can also be defined in a shorthand syntaxt which also contains the
+///   This can also be defined in a shorthand syntax which also contains the
 ///   total column count such as `3 of 5`.
 ///
 /// @argument {map} $grid [$neat-grid]


### PR DESCRIPTION
Removes a stray character.

- [X] Commit message has a short title & issue references
- [X] Commits are squashed
- [X] The build will pass (run `bundle exec rake`).